### PR TITLE
Brevo Transactional Email APIをメール送信モードとして追加

### DIFF
--- a/reunion/.env.example
+++ b/reunion/.env.example
@@ -15,15 +15,19 @@ FLASK_ENV=development
 # --- メール設定 ---
 # MAIL_MODE=console   ... コンソール出力（開発環境・実送信しない）
 # MAIL_MODE=smtp      ... SMTPで実際に送信
+# MAIL_MODE=brevo     ... Brevo APIで送信（推奨）
 MAIL_MODE=console
+
+# Brevo設定（MAIL_MODE=brevo の場合のみ必要）
+BREVO_API_KEY=your-brevo-api-key
+MAIL_FROM=your-email@gmail.com
+MAIL_FROM_NAME=同窓会幹事
 
 # SMTP設定（MAIL_MODE=smtp の場合のみ必要）
 MAIL_SMTP_HOST=smtp.gmail.com
 MAIL_SMTP_PORT=587
 MAIL_SMTP_USER=your-email@gmail.com
 MAIL_SMTP_PASSWORD=your-app-password
-MAIL_FROM=your-email@gmail.com
-MAIL_FROM_NAME=同窓会幹事
 
 # --- アプリURL（本出欠メールに使用） ---
 # ローカル実行時はそのままでOK

--- a/reunion/config.py
+++ b/reunion/config.py
@@ -40,7 +40,8 @@ class Config:
     # -----------------------------------------------
     # メール設定
     # -----------------------------------------------
-    MAIL_MODE = os.getenv("MAIL_MODE", "console")  # "console" or "smtp"
+    MAIL_MODE = os.getenv("MAIL_MODE", "console")  # "console" / "smtp" / "brevo"
+    BREVO_API_KEY = os.getenv("BREVO_API_KEY", "")
     MAIL_SMTP_HOST = os.getenv("MAIL_SMTP_HOST", "smtp.gmail.com")
     MAIL_SMTP_PORT = int(os.getenv("MAIL_SMTP_PORT", "587"))
     MAIL_SMTP_USER = os.getenv("MAIL_SMTP_USER", "")

--- a/reunion/routes/admin.py
+++ b/reunion/routes/admin.py
@@ -998,7 +998,8 @@ def csv_delete_all():
 def settings_mail():
     """メール設定画面（送信アカウントの確認・変更）"""
     KEYS = [
-        "mail_mode", "mail_smtp_host", "mail_smtp_port",
+        "mail_mode", "brevo_api_key",
+        "mail_smtp_host", "mail_smtp_port",
         "mail_smtp_user", "mail_smtp_password",
         "mail_from", "mail_from_name", "mail_daily_limit",
     ]
@@ -1006,7 +1007,7 @@ def settings_mail():
     if request.method == "POST":
         for key in KEYS:
             val = request.form.get(key, "").strip()
-            if key == "mail_smtp_password" and not val:
+            if key in ("mail_smtp_password", "brevo_api_key") and not val:
                 continue
             setting = AppSetting.query.filter_by(key=key).first()
             if setting:

--- a/reunion/services/mail_service.py
+++ b/reunion/services/mail_service.py
@@ -4,6 +4,7 @@ services/mail_service.py - メール送信サービス
 MAIL_MODE=console の場合: コンソールに出力するだけ（開発用）
 MAIL_MODE=smtp    の場合: SMTPで実際に送信する
 MAIL_MODE=gas     の場合: GAS Webhookで送信する
+MAIL_MODE=brevo   の場合: Brevo Transactional Email APIで送信する
 """
 import json
 import os
@@ -289,6 +290,34 @@ def _send_smtp_cfg(to_email: str, subject: str, body: str, cfg: dict, attachment
         server.sendmail(cfg["from_addr"], [to_email], msg.as_string())
 
 
+def _send_brevo(to_email: str, subject: str, body: str, cfg: dict) -> None:
+    """Brevo Transactional Email APIでメールを送信する"""
+    api_key = os.environ.get("BREVO_API_KEY", "") or current_app.config.get("BREVO_API_KEY", "")
+    if not api_key:
+        raise ValueError("BREVO_API_KEY が設定されていません")
+
+    payload = json.dumps({
+        "sender":   {"name": cfg["from_name"], "email": cfg["from_addr"]},
+        "to":       [{"email": to_email}],
+        "subject":  subject,
+        "textContent": body,
+    }).encode("utf-8")
+
+    req = urllib.request.Request(
+        "https://api.brevo.com/v3/smtp/email",
+        data=payload,
+        headers={
+            "Content-Type":  "application/json",
+            "Accept":        "application/json",
+            "api-key":       api_key,
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=30) as res:
+        if res.status not in (200, 201):
+            raise RuntimeError(f"Brevo APIエラー: HTTP {res.status}")
+
+
 def _send_console(to_email: str, subject: str, body: str) -> None:
     """コンソールにメール内容を出力する。開発用。"""
     separator = "=" * 60
@@ -327,6 +356,9 @@ def _dispatch_send(to_email: str, subject: str, body: str, mail_cfg: dict, attac
         return "sent"
     elif mode == "smtp":
         _send_smtp_cfg(to_email, subject, body, mail_cfg, attachment_path=attachment_path)
+        return "sent"
+    elif mode == "brevo":
+        _send_brevo(to_email, subject, body, mail_cfg)
         return "sent"
     else:
         if attachment_path:

--- a/reunion/templates/admin/settings_mail.html
+++ b/reunion/templates/admin/settings_mail.html
@@ -41,6 +41,26 @@
                   GAS送信（Render環境向け）
                 </label>
               </div>
+              <div class="form-check">
+                <input class="form-check-input" type="radio" name="mail_mode"
+                       id="mode_brevo" value="brevo"
+                       {% if settings.get('mail_mode') == 'brevo' %}checked{% endif %}>
+                <label class="form-check-label" for="mode_brevo">
+                  Brevo API送信（推奨）
+                </label>
+              </div>
+            </div>
+          </div>
+
+          <hr class="my-3">
+
+          <!-- Brevo APIキー -->
+          <div class="mb-3">
+            <label class="form-label fw-bold">Brevo APIキー</label>
+            <input type="password" class="form-control" name="brevo_api_key"
+                   placeholder="入力しない場合は変更されません">
+            <div class="form-text">
+              Brevo → 右上アカウント名 → SMTP &amp; API → APIキー で取得できます。
             </div>
           </div>
 


### PR DESCRIPTION
- mail_service.py: urllib使用の_send_brevo()関数を追加、_dispatch_send()にbrevoモード分岐を追加
- config.py: BREVO_API_KEY設定を追加
- admin.py: settings_mailのKEYSにbrevo_api_keyを追加、空入力時はスキップ
- settings_mail.html: Brevo送信モード選択ラジオとAPIキー入力欄を追加
- .env.example: BREVO_API_KEY設定例を追加