### PR TITLE
署名スペース削除・本出欠締切を統一・リマインド送信日を分離

### DIFF
--- a/reunion/routes/admin.py
+++ b/reunion/routes/admin.py
@@ -335,16 +335,16 @@ PHASE_LABELS = {
 }
 
 
-def _get_final_deadline_passed() -> bool:
-    """本出欠の回答期限を過ぎているか判定する。期限未設定の場合は True を返す。"""
+def _get_reminder_send_date_passed() -> bool:
+    """リマインドメール送信日を過ぎているか判定する。未設定の場合は False（自動判定に含まれない）。"""
     from datetime import date as _date
-    s = AppSetting.query.filter_by(key="final_deadline").first()
+    s = AppSetting.query.filter_by(key="reminder_send_date").first()
     if not (s and s.value):
-        return True
+        return False
     try:
-        return _date.today() > _date.fromisoformat(s.value)
+        return _date.today() >= _date.fromisoformat(s.value)
     except ValueError:
-        return True
+        return False
 
 
 def _get_final_reminder_date_passed() -> bool:
@@ -365,7 +365,7 @@ def _collect_pending_jobs(base_url: str) -> list:
     各要素: {"phase": str, "pid": int, "final_url": str|None}
 
     Phase 1 (final_url):      常時 — 仮出欠回答済み & URL未送信
-    Phase 2 (reminder):       final_deadline 超過 & URL送信済み & 本出欠未回答
+    Phase 2 (reminder):       reminder_send_date 以降 & URL送信済み & 本出欠未回答
     Phase 3 (final_reminder): final_reminder_date 以降 & 本参加確定 & 最終リマインド未送信
     """
     participants = Participant.query.filter(
@@ -379,7 +379,7 @@ def _collect_pending_jobs(base_url: str) -> list:
             if not any(ml.mail_type == "final_url" and ml.status in ("sent", "simulated") for ml in p.mail_logs):
                 jobs.append({"phase": "final_url", "pid": p.id, "final_url": generate_final_url(p, base_url)})
 
-    if _get_final_deadline_passed():
+    if _get_reminder_send_date_passed():
         for p in participants:
             has_url = any(ml.mail_type == "final_url" and ml.status in ("sent", "simulated") for ml in p.mail_logs)
             has_reminded = any(ml.mail_type == "reminder" and ml.status in ("sent", "simulated") for ml in p.mail_logs)
@@ -567,8 +567,6 @@ def api_mail_preview(mail_type):
         "organizer_name": reunion["organizer_name"],
         "final_deadline": reunion["final_deadline"],
         "final_deadline_short": reunion["final_deadline_short"],
-        "reminder_deadline": reunion["reminder_deadline"],
-        "reminder_deadline_short": reunion["reminder_deadline_short"],
         "final_reminder_deadline": reunion["final_reminder_deadline"],
         "final_reminder_deadline_short": reunion["final_reminder_deadline_short"],
         "final_url": f"{base_url}/form/final/（トークン）",
@@ -601,7 +599,7 @@ def api_mail_preview(mail_type):
                 if not has_sent:
                     targets.append(p)
     elif mail_type == "reminder":
-        if _get_final_deadline_passed():
+        if _get_reminder_send_date_passed():
             for p in participants:
                 has_url = any(ml.mail_type == "final_url" and ml.status in ("sent", "simulated") for ml in p.mail_logs)
                 has_reminded = any(ml.mail_type == "reminder" and ml.status in ("sent", "simulated") for ml in p.mail_logs)
@@ -1224,7 +1222,7 @@ def settings_reunion():
     KEYS = [
         "reunion_name", "organizer_name", "reunion_date", "reunion_time", "reunion_venue", "reunion_fee",
         "dress_code", "belongings", "provisional_deadline",
-        "final_deadline", "reminder_deadline", "final_reminder_deadline", "final_reminder_date",
+        "final_deadline", "reminder_send_date", "final_reminder_deadline", "final_reminder_date",
         "transfer_bank", "transfer_branch", "transfer_branch_number",
         "transfer_account_type", "transfer_account_number", "transfer_account_name", "transfer_deadline",
     ]

--- a/reunion/services/mail_service.py
+++ b/reunion/services/mail_service.py
@@ -30,7 +30,7 @@ MAIL_DEFAULTS = {
     "mail_final_url_body": (
         "{name} 様\n\n"
         "ご無沙汰しております。\n"
-        "{reunion_name}幹事代表の{organizer_name} です。\n\n"
+        "{reunion_name}幹事代表の{organizer_name}です。\n\n"
         "先日は仮出欠にご回答いただき、ありがとうございました。\n"
         "つきましては、本出欠フォームのURLをお送りします。\n\n"
         "━━━━━━━━━━━━━━━━━━━━\n"
@@ -51,14 +51,14 @@ MAIL_DEFAULTS = {
         "ご不明な点がございましたら、お気軽にご連絡ください。\n\n"
         "──────────────────\n"
         "{reunion_name} 幹事代表 {organizer_name}\n"
-        "E-mail: {organizer_email}"
+        "E-mail: {mail_from}"
     ),
     # ── 本出欠リマインド（生徒用） ───────────────────────────
-    "mail_reminder_subject": "【{reminder_deadline_short} 23:59締切】【{reunion_name}】本出欠のご回答をお願いします（リマインド）",
+    "mail_reminder_subject": "【{final_deadline_short} 23:59締切】【{reunion_name}】本出欠のご回答をお願いします（リマインド）",
     "mail_reminder_body": (
         "{name} 様\n\n"
         "ご無沙汰しております。\n"
-        "{reunion_name}幹事代表の{organizer_name} です。\n\n"
+        "{reunion_name}幹事代表の{organizer_name}です。\n\n"
         "先日お送りした本出欠フォームについて、改めてご連絡いたします。\n"
         "ご回答済みの方はご放念ください。\n\n"
         "━━━━━━━━━━━━━━━━━━━━\n"
@@ -73,17 +73,17 @@ MAIL_DEFAULTS = {
         "■ 本出欠フォーム\n"
         "━━━━━━━━━━━━━━━━━━━━\n"
         "{final_url}\n\n"
-        "※回答期限（{reminder_deadline_short} 23:59）まで何度でも変更できます。\n\n"
+        "※回答期限（{final_deadline_short} 23:59）まで何度でも変更できます。\n\n"
         "お忙しいところ恐れ入りますが、よろしくお願いいたします。\n\n"
         "──────────────────\n"
         "{reunion_name} 幹事代表 {organizer_name}\n"
-        "E-mail: {organizer_email}"
+        "E-mail: {mail_from}"
     ),
     # ── 仮出欠 送信完了 ──────────────────────────────────
     "mail_provisional_confirm_subject": "【{reunion_name}】仮出欠を受け付けました",
     "mail_provisional_confirm_body": (
         "{name} 様\n\n"
-        "{reunion_name}幹事代表の{organizer_name} です。\n"
+        "{reunion_name}幹事代表の{organizer_name}です。\n"
         "仮出欠のご回答ありがとうございます。\n"
         "以下の内容で受け付けました。\n\n"
         "━━━━━━━━━━━━━━━━━━━━\n"
@@ -105,14 +105,14 @@ MAIL_DEFAULTS = {
         "引き続きよろしくお願いいたします。\n\n"
         "──────────────────\n"
         "{reunion_name} 幹事代表 {organizer_name}\n"
-        "E-mail: {organizer_email}"
+        "E-mail: {mail_from}"
     ),
     # ── 最終リマインド（生徒用） ─────────────────────────────
     "mail_final_reminder_subject": "【{final_reminder_deadline_short} 23:59までに】【{reunion_name}】開催のご案内（最終リマインド）",
     "mail_final_reminder_body": (
         "{name} 様\n\n"
         "ご無沙汰しております。\n"
-        "{reunion_name}幹事代表の{organizer_name} です。\n\n"
+        "{reunion_name}幹事代表の{organizer_name}です。\n\n"
         "本出欠にてご参加のご回答をいただき、ありがとうございます。\n"
         "開催が近づいてまいりましたので、最終のご案内をお送りいたします。\n\n"
         "━━━━━━━━━━━━━━━━━━━━\n"
@@ -128,13 +128,13 @@ MAIL_DEFAULTS = {
         "当日お会いできることを楽しみにしております。\n\n"
         "──────────────────\n"
         "{reunion_name} 幹事代表 {organizer_name}\n"
-        "E-mail: {organizer_email}"
+        "E-mail: {mail_from}"
     ),
     # ── 仮出欠リマインド ─────────────────────────────────
     "mail_provisional_reminder_subject": "【{reunion_name}】仮出欠のご回答をお願いします（リマインド）",
     "mail_provisional_reminder_body": (
         "{name} 様\n\n"
-        "{reunion_name}幹事代表の{organizer_name} です。\n\n"
+        "{reunion_name}幹事代表の{organizer_name}です。\n\n"
         "先日ご案内しました仮出欠フォームへのご回答がまだのようでしたので、\n"
         "リマインドのご連絡を差し上げました。\n\n"
         "━━━━━━━━━━━━━━━━━━━━\n"
@@ -153,14 +153,14 @@ MAIL_DEFAULTS = {
         "お忙しいところ恐れ入りますが、ご確認のほどよろしくお願いいたします。\n\n"
         "──────────────────\n"
         "{reunion_name} 幹事代表 {organizer_name}\n"
-        "E-mail: {organizer_email}"
+        "E-mail: {mail_from}"
     ),
     # ── 先生向けテンプレート ──────────────────────────────
     "mail_final_url_subject_teacher": "【{final_deadline_short} 23:59締切】【{reunion_name}】ご出席のご確認をお願いいたします",
     "mail_final_url_body_teacher": (
         "{name} 先生\n\n"
         "ご無沙汰しております。\n"
-        "{reunion_name}幹事代表の{organizer_name} です。\n\n"
+        "{reunion_name}幹事代表の{organizer_name}です。\n\n"
         "このたびは{reunion_name}を開催する運びとなりました。\n"
         "先生にもぜひご出席いただければ、生徒一同大変嬉しく思います。\n\n"
         "ご多用の中大変恐れ入りますが、ご都合がよろしければ\n"
@@ -182,13 +182,13 @@ MAIL_DEFAULTS = {
         "先生のご出席を心よりお待ちしております。\n\n"
         "──────────────────\n"
         "{reunion_name} 幹事代表 {organizer_name}\n"
-        "E-mail: {organizer_email}"
+        "E-mail: {mail_from}"
     ),
-    "mail_reminder_subject_teacher": "【{reminder_deadline_short} 23:59締切】【{reunion_name}】ご出席のご確認（リマインド）",
+    "mail_reminder_subject_teacher": "【{final_deadline_short} 23:59締切】【{reunion_name}】ご出席のご確認（リマインド）",
     "mail_reminder_body_teacher": (
         "{name} 先生\n\n"
         "ご無沙汰しております。\n"
-        "{reunion_name}幹事代表の{organizer_name} です。\n\n"
+        "{reunion_name}幹事代表の{organizer_name}です。\n\n"
         "先日お送りした出欠フォームについて、改めてご連絡いたします。\n"
         "ご回答済みの場合はご放念ください。\n\n"
         "ご多用の中お手数をおかけして恐れ入りますが、\n"
@@ -205,16 +205,16 @@ MAIL_DEFAULTS = {
         "■ 出欠フォーム\n"
         "━━━━━━━━━━━━━━━━━━━━\n"
         "{final_url}\n\n"
-        "※ご回答期限（{reminder_deadline_short} 23:59）まで何度でも変更いただけます。\n\n"
+        "※ご回答期限（{final_deadline_short} 23:59）まで何度でも変更いただけます。\n\n"
         "──────────────────\n"
         "{reunion_name} 幹事代表 {organizer_name}\n"
-        "E-mail: {organizer_email}"
+        "E-mail: {mail_from}"
     ),
     "mail_final_reminder_subject_teacher": "【{final_reminder_deadline_short} 23:59までに】【{reunion_name}】開催のご案内（最終リマインド）",
     "mail_final_reminder_body_teacher": (
         "{name} 先生\n\n"
         "ご無沙汰しております。\n"
-        "{reunion_name}幹事代表の{organizer_name} です。\n\n"
+        "{reunion_name}幹事代表の{organizer_name}です。\n\n"
         "ご出席のご回答をいただき、誠にありがとうございます。\n"
         "開催が近づいてまいりましたので、最終のご案内をお送りいたします。\n\n"
         "━━━━━━━━━━━━━━━━━━━━\n"
@@ -230,14 +230,14 @@ MAIL_DEFAULTS = {
         "先生にお会いできることを楽しみにしております。\n\n"
         "──────────────────\n"
         "{reunion_name} 幹事代表 {organizer_name}\n"
-        "E-mail: {organizer_email}"
+        "E-mail: {mail_from}"
     ),
     # ── ここまで先生向けテンプレート ─────────────────────────
 
     "mail_final_confirm_subject": "【{reunion_name}】本出欠を受け付けました",
     "mail_final_confirm_body": (
         "{name} 様\n\n"
-        "{reunion_name}幹事代表の{organizer_name} です。\n"
+        "{reunion_name}幹事代表の{organizer_name}です。\n"
         "本出欠のご回答ありがとうございます。\n"
         "以下の内容で受け付けました。\n\n"
         "━━━━━━━━━━━━━━━━━━━━\n"
@@ -257,7 +257,7 @@ MAIL_DEFAULTS = {
         "ご不明な点がございましたら、お気軽にご連絡ください。\n\n"
         "──────────────────\n"
         "{reunion_name} 幹事代表 {organizer_name}\n"
-        "E-mail: {organizer_email}"
+        "E-mail: {mail_from}"
     ),
 }
 
@@ -324,13 +324,12 @@ def _get_reunion_info() -> dict:
         "transfer_account_name":   get("transfer_account_name",   cfg.get("TRANSFER_ACCOUNT_NAME", "")),
         "transfer_deadline":       get("transfer_deadline",       cfg.get("TRANSFER_DEADLINE", "")),
         "organizer_name":          get("organizer_name",          cfg.get("ORGANIZER_NAME", "")),
-        "organizer_email":         get("mail_from",               cfg.get("MAIL_FROM", "")),
+        "mail_from":               get("mail_from",               cfg.get("MAIL_FROM", "")),
         "final_deadline":          get("final_deadline",          cfg.get("FINAL_DEADLINE", "")),
-        "reminder_deadline":       get("reminder_deadline",       cfg.get("REMINDER_DEADLINE", "")),
+        "reminder_send_date":      get("reminder_send_date",      cfg.get("REMINDER_SEND_DATE", "")),
         "final_reminder_deadline": get("final_reminder_deadline", cfg.get("FINAL_REMINDER_DEADLINE", "")),
     }
     info["final_deadline_short"]          = _format_deadline_short(info["final_deadline"])
-    info["reminder_deadline_short"]       = _format_deadline_short(info["reminder_deadline"])
     info["final_reminder_deadline_short"] = _format_deadline_short(info["final_reminder_deadline"])
     return info
 
@@ -350,11 +349,9 @@ def _build_final_url_mail_body(participant_name: str, final_url: str, role: str 
         dress_code=reunion["dress_code"],
         belongings=reunion["belongings"],
         organizer_name=reunion["organizer_name"],
-        organizer_email=reunion["organizer_email"],
+        mail_from=reunion["mail_from"],
         final_deadline=reunion["final_deadline"],
         final_deadline_short=reunion["final_deadline_short"],
-        reminder_deadline=reunion["reminder_deadline"],
-        reminder_deadline_short=reunion["reminder_deadline_short"],
         final_reminder_deadline=reunion["final_reminder_deadline"],
         final_reminder_deadline_short=reunion["final_reminder_deadline_short"],
     )
@@ -380,11 +377,9 @@ def _build_reminder_mail_body(participant_name: str, final_url: str, role: str =
         dress_code=reunion["dress_code"],
         belongings=reunion["belongings"],
         organizer_name=reunion["organizer_name"],
-        organizer_email=reunion["organizer_email"],
+        mail_from=reunion["mail_from"],
         final_deadline=reunion["final_deadline"],
         final_deadline_short=reunion["final_deadline_short"],
-        reminder_deadline=reunion["reminder_deadline"],
-        reminder_deadline_short=reunion["reminder_deadline_short"],
         final_reminder_deadline=reunion["final_reminder_deadline"],
         final_reminder_deadline_short=reunion["final_reminder_deadline_short"],
     )
@@ -573,11 +568,9 @@ def _build_provisional_confirm_body(participant_name: str, status_label: str, pr
         dress_code=reunion["dress_code"],
         belongings=reunion["belongings"],
         organizer_name=reunion["organizer_name"],
-        organizer_email=reunion["organizer_email"],
+        mail_from=reunion["mail_from"],
         final_deadline=reunion["final_deadline"],
         final_deadline_short=reunion["final_deadline_short"],
-        reminder_deadline=reunion["reminder_deadline"],
-        reminder_deadline_short=reunion["reminder_deadline_short"],
         final_reminder_deadline=reunion["final_reminder_deadline"],
         final_reminder_deadline_short=reunion["final_reminder_deadline_short"],
     )
@@ -627,7 +620,7 @@ def _build_final_confirm_body(participant_name: str, status_label: str, final_ur
         dress_code=reunion["dress_code"],
         belongings=reunion["belongings"],
         organizer_name=reunion["organizer_name"],
-        organizer_email=reunion["organizer_email"],
+        mail_from=reunion["mail_from"],
         transfer_bank=reunion["transfer_bank"],
         transfer_branch=reunion["transfer_branch"],
         transfer_branch_number=reunion["transfer_branch_number"],
@@ -637,8 +630,6 @@ def _build_final_confirm_body(participant_name: str, status_label: str, final_ur
         transfer_deadline=reunion["transfer_deadline"],
         final_deadline=reunion["final_deadline"],
         final_deadline_short=reunion["final_deadline_short"],
-        reminder_deadline=reunion["reminder_deadline"],
-        reminder_deadline_short=reunion["reminder_deadline_short"],
         final_reminder_deadline=reunion["final_reminder_deadline"],
         final_reminder_deadline_short=reunion["final_reminder_deadline_short"],
     )
@@ -672,11 +663,9 @@ def _build_provisional_reminder_body(participant_name: str, provisional_url: str
         dress_code=reunion["dress_code"],
         belongings=reunion["belongings"],
         organizer_name=reunion["organizer_name"],
-        organizer_email=reunion["organizer_email"],
+        mail_from=reunion["mail_from"],
         final_deadline=reunion["final_deadline"],
         final_deadline_short=reunion["final_deadline_short"],
-        reminder_deadline=reunion["reminder_deadline"],
-        reminder_deadline_short=reunion["reminder_deadline_short"],
         final_reminder_deadline=reunion["final_reminder_deadline"],
         final_reminder_deadline_short=reunion["final_reminder_deadline_short"],
     )
@@ -817,11 +806,9 @@ def _build_final_reminder_body(participant_name: str, role: str = "") -> tuple:
         dress_code=reunion["dress_code"],
         belongings=reunion["belongings"],
         organizer_name=reunion["organizer_name"],
-        organizer_email=reunion["organizer_email"],
+        mail_from=reunion["mail_from"],
         final_deadline=reunion["final_deadline"],
         final_deadline_short=reunion["final_deadline_short"],
-        reminder_deadline=reunion["reminder_deadline"],
-        reminder_deadline_short=reunion["reminder_deadline_short"],
         final_reminder_deadline=reunion["final_reminder_deadline"],
         final_reminder_deadline_short=reunion["final_reminder_deadline_short"],
     )

--- a/reunion/templates/admin/settings_mail_template.html
+++ b/reunion/templates/admin/settings_mail_template.html
@@ -37,7 +37,6 @@
     <span>幹事名 <code>{organizer_name}</code></span>
     <span>本出欠回答期限 <code>{final_deadline}</code></span>
     <span>本出欠回答期限（m/d） <code>{final_deadline_short}</code></span>
-    <span>リマインド回答期限（m/d） <code>{reminder_deadline_short}</code></span>
     <span>最終リマインドキャンセル期限（m/d） <code>{final_reminder_deadline_short}</code></span>
     <span>日程 <code>{reunion_date}</code></span>
     <span>時刻 <code>{reunion_time}</code></span>

--- a/reunion/templates/admin/settings_reunion.html
+++ b/reunion/templates/admin/settings_reunion.html
@@ -112,10 +112,10 @@
           </div>
 
           <div class="mb-3">
-            <label class="form-label fw-bold">本出欠リマインド 回答期限</label>
-            <input type="date" class="form-control" name="reminder_deadline"
-                   value="{{ settings.get('reminder_deadline', '') }}">
-            <div class="form-text">本出欠リマインドメールに表示される期限。</div>
+            <label class="form-label fw-bold">リマインドメール 送信日</label>
+            <input type="date" class="form-control" name="reminder_send_date"
+                   value="{{ settings.get('reminder_send_date', '') }}">
+            <div class="form-text">この日以降、本出欠未回答者がリマインド送信の対象になります。</div>
           </div>
 
           <div class="mb-3">


### PR DESCRIPTION
- 幹事名後のスペース削除（「{organizer_name} です」→「{organizer_name}です」）
- 本出欠URLメール・リマインドメールの締切を {final_deadline_short} に統一
- reminder_deadline 廃止、代わりに reminder_send_date（リマインドメール送信日）を新設
- Phase 2 トリガーを final_deadline → reminder_send_date に変更
- settings_reunion.html の該当フィールドを更新