### PR TITLE
仮出欠・本出欠確認メールに先生バリアントを追加

### DIFF
--- a/reunion/routes/admin.py
+++ b/reunion/routes/admin.py
@@ -1163,17 +1163,22 @@ def settings_pdf_upload():
 def settings_mail_template():
     """メール文章編集画面"""
     KEYS = [
-        "mail_provisional_confirm_attending_subject",     "mail_provisional_confirm_attending_body",
-        "mail_provisional_confirm_not_attending_subject", "mail_provisional_confirm_not_attending_body",
-        "mail_provisional_confirm_undecided_subject",     "mail_provisional_confirm_undecided_body",
-        "mail_final_url_subject",                         "mail_final_url_body",
-        "mail_final_url_subject_teacher",                 "mail_final_url_body_teacher",
-        "mail_reminder_subject",                          "mail_reminder_body",
-        "mail_reminder_subject_teacher",                  "mail_reminder_body_teacher",
-        "mail_final_confirm_attending_subject",           "mail_final_confirm_attending_body",
-        "mail_final_confirm_not_attending_subject",       "mail_final_confirm_not_attending_body",
-        "mail_final_reminder_subject",                    "mail_final_reminder_body",
-        "mail_final_reminder_subject_teacher",            "mail_final_reminder_body_teacher",
+        "mail_provisional_confirm_attending_subject",             "mail_provisional_confirm_attending_body",
+        "mail_provisional_confirm_attending_subject_teacher",     "mail_provisional_confirm_attending_body_teacher",
+        "mail_provisional_confirm_not_attending_subject",         "mail_provisional_confirm_not_attending_body",
+        "mail_provisional_confirm_not_attending_subject_teacher", "mail_provisional_confirm_not_attending_body_teacher",
+        "mail_provisional_confirm_undecided_subject",             "mail_provisional_confirm_undecided_body",
+        "mail_provisional_confirm_undecided_subject_teacher",     "mail_provisional_confirm_undecided_body_teacher",
+        "mail_final_url_subject",                                 "mail_final_url_body",
+        "mail_final_url_subject_teacher",                         "mail_final_url_body_teacher",
+        "mail_reminder_subject",                                  "mail_reminder_body",
+        "mail_reminder_subject_teacher",                          "mail_reminder_body_teacher",
+        "mail_final_confirm_attending_subject",                   "mail_final_confirm_attending_body",
+        "mail_final_confirm_attending_subject_teacher",           "mail_final_confirm_attending_body_teacher",
+        "mail_final_confirm_not_attending_subject",               "mail_final_confirm_not_attending_body",
+        "mail_final_confirm_not_attending_subject_teacher",       "mail_final_confirm_not_attending_body_teacher",
+        "mail_final_reminder_subject",                            "mail_final_reminder_body",
+        "mail_final_reminder_subject_teacher",                    "mail_final_reminder_body_teacher",
     ]
     if request.method == "POST":
         for key in KEYS:

--- a/reunion/services/mail_service.py
+++ b/reunion/services/mail_service.py
@@ -275,6 +275,139 @@ MAIL_DEFAULTS = {
         "──────────────────\n"
         "{reunion_name} 幹事代表 {organizer_name}"
     ),
+    # ── 仮出欠 送信完了（参加予定・先生用） ───────────────────
+    "mail_provisional_confirm_attending_subject_teacher": "【{reunion_name}】仮出欠を受け付けました",
+    "mail_provisional_confirm_attending_body_teacher": (
+        "{name} 先生\n\n"
+        "{reunion_name}幹事代表の{organizer_name}です。\n"
+        "仮出欠のご回答をいただき、誠にありがとうございます。\n"
+        "以下の内容で受け付けました。\n\n"
+        "━━━━━━━━━━━━━━━━━━━━\n"
+        "■ ご回答内容\n"
+        "━━━━━━━━━━━━━━━━━━━━\n"
+        "回答: {status}\n\n"
+        "━━━━━━━━━━━━━━━━━━━━\n"
+        "■ 同窓会の詳細\n"
+        "━━━━━━━━━━━━━━━━━━━━\n"
+        "日時: {reunion_date} {reunion_time}\n"
+        "会場: {reunion_venue}\n"
+        "服装: {dress_code}\n"
+        "持ち物: {belongings}\n"
+        "会費: {reunion_fee}\n\n"
+        "内容を変更する場合は、下記URLから再度ご回答ください。\n"
+        "{provisional_url}\n\n"
+        "後日、本出欠フォームのURLを別途お送りいたします。\n"
+        "引き続きよろしくお願いいたします。\n\n"
+        "──────────────────\n"
+        "{reunion_name} 幹事代表 {organizer_name}"
+    ),
+    # ── 仮出欠 送信完了（不参加・先生用） ─────────────────────
+    "mail_provisional_confirm_not_attending_subject_teacher": "【{reunion_name}】仮出欠を受け付けました",
+    "mail_provisional_confirm_not_attending_body_teacher": (
+        "{name} 先生\n\n"
+        "{reunion_name}幹事代表の{organizer_name}です。\n"
+        "仮出欠のご回答をいただき、誠にありがとうございます。\n"
+        "以下の内容で受け付けました。\n\n"
+        "━━━━━━━━━━━━━━━━━━━━\n"
+        "■ ご回答内容\n"
+        "━━━━━━━━━━━━━━━━━━━━\n"
+        "回答: {status}\n\n"
+        "━━━━━━━━━━━━━━━━━━━━\n"
+        "■ 同窓会の詳細\n"
+        "━━━━━━━━━━━━━━━━━━━━\n"
+        "日時: {reunion_date} {reunion_time}\n"
+        "会場: {reunion_venue}\n"
+        "服装: {dress_code}\n"
+        "持ち物: {belongings}\n"
+        "会費: {reunion_fee}\n\n"
+        "内容を変更する場合は、下記URLから再度ご回答ください。\n"
+        "{provisional_url}\n\n"
+        "引き続きよろしくお願いいたします。\n\n"
+        "──────────────────\n"
+        "{reunion_name} 幹事代表 {organizer_name}"
+    ),
+    # ── 仮出欠 送信完了（未定・先生用） ───────────────────────
+    "mail_provisional_confirm_undecided_subject_teacher": "【{reunion_name}】仮出欠を受け付けました",
+    "mail_provisional_confirm_undecided_body_teacher": (
+        "{name} 先生\n\n"
+        "{reunion_name}幹事代表の{organizer_name}です。\n"
+        "仮出欠のご回答をいただき、誠にありがとうございます。\n"
+        "以下の内容で受け付けました。\n\n"
+        "━━━━━━━━━━━━━━━━━━━━\n"
+        "■ ご回答内容\n"
+        "━━━━━━━━━━━━━━━━━━━━\n"
+        "回答: {status}\n\n"
+        "━━━━━━━━━━━━━━━━━━━━\n"
+        "■ 同窓会の詳細\n"
+        "━━━━━━━━━━━━━━━━━━━━\n"
+        "日時: {reunion_date} {reunion_time}\n"
+        "会場: {reunion_venue}\n"
+        "服装: {dress_code}\n"
+        "持ち物: {belongings}\n"
+        "会費: {reunion_fee}\n\n"
+        "内容を変更する場合は、下記URLから再度ご回答ください。\n"
+        "{provisional_url}\n\n"
+        "後日、本出欠フォームのURLを別途お送りいたします。\n"
+        "引き続きよろしくお願いいたします。\n\n"
+        "──────────────────\n"
+        "{reunion_name} 幹事代表 {organizer_name}"
+    ),
+    # ── 本出欠 送信完了（参加・先生用） ───────────────────────
+    "mail_final_confirm_attending_subject_teacher": "【{reunion_name}】出欠を受け付けました",
+    "mail_final_confirm_attending_body_teacher": (
+        "{name} 先生\n\n"
+        "{reunion_name}幹事代表の{organizer_name}です。\n"
+        "ご出欠のご回答をいただき、誠にありがとうございます。\n"
+        "以下の内容で受け付けました。\n\n"
+        "━━━━━━━━━━━━━━━━━━━━\n"
+        "■ ご回答内容\n"
+        "━━━━━━━━━━━━━━━━━━━━\n"
+        "回答: {status}\n\n"
+        "━━━━━━━━━━━━━━━━━━━━\n"
+        "■ 同窓会の詳細\n"
+        "━━━━━━━━━━━━━━━━━━━━\n"
+        "日時: {reunion_date} {reunion_time}\n"
+        "会場: {reunion_venue}\n"
+        "服装: {dress_code}\n"
+        "持ち物: {belongings}\n\n"
+        "━━━━━━━━━━━━━━━━━━━━\n"
+        "■ 振込のご案内\n"
+        "━━━━━━━━━━━━━━━━━━━━\n"
+        "会費: {reunion_fee}\n"
+        "振込先: {transfer_bank} {transfer_branch}（支店番号: {transfer_branch_number}）\n"
+        "口座: {transfer_account_type}口座 {transfer_account_number}\n"
+        "口座名義: {transfer_account_name}\n"
+        "振込期限: {transfer_deadline}\n\n"
+        "内容を変更する場合は、下記URLから再度ご回答ください。\n"
+        "{final_url}\n\n"
+        "ご不明な点がございましたら、このメールへのご返信にてお気軽にご連絡ください。\n\n"
+        "──────────────────\n"
+        "{reunion_name} 幹事代表 {organizer_name}"
+    ),
+    # ── 本出欠 送信完了（不参加・先生用） ─────────────────────
+    "mail_final_confirm_not_attending_subject_teacher": "【{reunion_name}】出欠を受け付けました",
+    "mail_final_confirm_not_attending_body_teacher": (
+        "{name} 先生\n\n"
+        "{reunion_name}幹事代表の{organizer_name}です。\n"
+        "ご出欠のご回答をいただき、誠にありがとうございます。\n"
+        "以下の内容で受け付けました。\n\n"
+        "━━━━━━━━━━━━━━━━━━━━\n"
+        "■ ご回答内容\n"
+        "━━━━━━━━━━━━━━━━━━━━\n"
+        "回答: {status}\n\n"
+        "━━━━━━━━━━━━━━━━━━━━\n"
+        "■ 同窓会の詳細\n"
+        "━━━━━━━━━━━━━━━━━━━━\n"
+        "日時: {reunion_date} {reunion_time}\n"
+        "会場: {reunion_venue}\n"
+        "服装: {dress_code}\n"
+        "持ち物: {belongings}\n\n"
+        "内容を変更する場合は、下記URLから再度ご回答ください。\n"
+        "{final_url}\n\n"
+        "ご不明な点がございましたら、このメールへのご返信にてお気軽にご連絡ください。\n\n"
+        "──────────────────\n"
+        "{reunion_name} 幹事代表 {organizer_name}"
+    ),
     # ── ここまで先生向けテンプレート ─────────────────────────
 
     # ── 本出欠 送信完了（参加） ──────────────────────────────
@@ -641,11 +774,12 @@ def send_final_url(participant, final_url: str) -> MailLog:
     return log
 
 
-def _build_provisional_confirm_body(participant_name: str, status_label: str, provisional_url: str, status: str = "attending") -> tuple:
-    """仮出欠送信完了メールの件名・本文を生成する（statusキーでテンプレートを切り替え）"""
+def _build_provisional_confirm_body(participant_name: str, status_label: str, provisional_url: str, status: str = "attending", role: str = "") -> tuple:
+    """仮出欠送信完了メールの件名・本文を生成する（status・roleでテンプレートを切り替え）"""
     key_suffix = {"attending": "attending", "not_attending": "not_attending"}.get(status, "undecided")
-    s_key = f"mail_provisional_confirm_{key_suffix}_subject"
-    b_key = f"mail_provisional_confirm_{key_suffix}_body"
+    teacher_suffix = "_teacher" if _is_teacher(role) else ""
+    s_key = f"mail_provisional_confirm_{key_suffix}_subject{teacher_suffix}"
+    b_key = f"mail_provisional_confirm_{key_suffix}_body{teacher_suffix}"
     reunion = _get_reunion_info()
     vars = dict(
         name=participant_name,
@@ -669,11 +803,12 @@ def _build_provisional_confirm_body(participant_name: str, status_label: str, pr
     return subject, body
 
 
-def _build_final_confirm_body(participant_name: str, status_label: str, final_url: str, status: str = "attending") -> tuple:
-    """本出欠送信完了メールの件名・本文を生成する（statusキーでテンプレートを切り替え）"""
+def _build_final_confirm_body(participant_name: str, status_label: str, final_url: str, status: str = "attending", role: str = "") -> tuple:
+    """本出欠送信完了メールの件名・本文を生成する（status・roleでテンプレートを切り替え）"""
     key_suffix = "attending" if status == "attending" else "not_attending"
-    s_key = f"mail_final_confirm_{key_suffix}_subject"
-    b_key = f"mail_final_confirm_{key_suffix}_body"
+    teacher_suffix = "_teacher" if _is_teacher(role) else ""
+    s_key = f"mail_final_confirm_{key_suffix}_subject{teacher_suffix}"
+    b_key = f"mail_final_confirm_{key_suffix}_body{teacher_suffix}"
     reunion = _get_reunion_info()
     vars = dict(
         name=participant_name,
@@ -771,7 +906,7 @@ def send_provisional_reminder(participant, provisional_url: str) -> MailLog:
 def send_provisional_confirmation(participant, status_label: str, provisional_url: str, status: str = "attending") -> MailLog:
     """仮出欠フォーム送信完了メールを送信する。"""
     mail_cfg = _get_mail_config()
-    subject, body = _build_provisional_confirm_body(participant.name, status_label, provisional_url, status)
+    subject, body = _build_provisional_confirm_body(participant.name, status_label, provisional_url, status, participant.role or "")
 
     log = MailLog(
         participant_id=participant.id,
@@ -798,7 +933,7 @@ def send_provisional_confirmation(participant, status_label: str, provisional_ur
 def send_final_confirmation(participant, status_label: str, final_url: str, status: str = "attending") -> MailLog:
     """本出欠フォーム送信完了メールを送信する。"""
     mail_cfg = _get_mail_config()
-    subject, body = _build_final_confirm_body(participant.display_name, status_label, final_url, status)
+    subject, body = _build_final_confirm_body(participant.display_name, status_label, final_url, status, participant.role or "")
 
     log = MailLog(
         participant_id=participant.id,

--- a/reunion/templates/admin/settings_mail_template.html
+++ b/reunion/templates/admin/settings_mail_template.html
@@ -103,6 +103,27 @@
   <div class="col-lg-8">
     <form method="POST" action="{{ url_for('admin.settings_mail_template') }}">
 
+      <!-- 仮出欠送信完了（未定・先生用） -->
+      <div id="section_provisional_confirm_undecided_teacher" class="mail-section d-none">
+        <div class="card mb-4">
+          <div class="card-header fw-bold bg-light">
+            <i class="bi bi-check-circle me-1"></i>仮出欠 送信完了メール（未定・先生用）
+          </div>
+          <div class="card-body">
+            <div class="mb-3">
+              <label class="form-label fw-bold">件名</label>
+              <input type="text" class="form-control" name="mail_provisional_confirm_undecided_subject_teacher"
+                     value="{{ settings.get('mail_provisional_confirm_undecided_subject_teacher', '') }}">
+            </div>
+            <div class="mb-0">
+              <label class="form-label fw-bold">本文</label>
+              <textarea class="form-control font-monospace auto-resize" name="mail_provisional_confirm_undecided_body_teacher">{{ settings.get('mail_provisional_confirm_undecided_body_teacher', '') }}</textarea>
+              <div class="form-text">追加変数: <code>{status}</code> 回答内容、<code>{provisional_url}</code> 変更用URL</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <!-- 本出欠URL送信 -->
       <div id="section_final_url" class="mail-section d-none">
         <div class="card mb-4">
@@ -144,6 +165,27 @@
         </div>
       </div>
 
+      <!-- 仮出欠送信完了（参加予定・先生用） -->
+      <div id="section_provisional_confirm_attending_teacher" class="mail-section d-none">
+        <div class="card mb-4">
+          <div class="card-header fw-bold bg-light">
+            <i class="bi bi-check-circle me-1"></i>仮出欠 送信完了メール（参加予定・先生用）
+          </div>
+          <div class="card-body">
+            <div class="mb-3">
+              <label class="form-label fw-bold">件名</label>
+              <input type="text" class="form-control" name="mail_provisional_confirm_attending_subject_teacher"
+                     value="{{ settings.get('mail_provisional_confirm_attending_subject_teacher', '') }}">
+            </div>
+            <div class="mb-0">
+              <label class="form-label fw-bold">本文</label>
+              <textarea class="form-control font-monospace auto-resize" name="mail_provisional_confirm_attending_body_teacher">{{ settings.get('mail_provisional_confirm_attending_body_teacher', '') }}</textarea>
+              <div class="form-text">追加変数: <code>{status}</code> 回答内容、<code>{provisional_url}</code> 変更用URL</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <!-- 仮出欠送信完了（不参加） -->
       <div id="section_provisional_confirm_not_attending" class="mail-section d-none">
         <div class="card mb-4">
@@ -159,6 +201,27 @@
             <div class="mb-0">
               <label class="form-label fw-bold">本文</label>
               <textarea class="form-control font-monospace auto-resize" name="mail_provisional_confirm_not_attending_body">{{ settings.get('mail_provisional_confirm_not_attending_body', '') }}</textarea>
+              <div class="form-text">追加変数: <code>{status}</code> 回答内容、<code>{provisional_url}</code> 変更用URL</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 仮出欠送信完了（不参加・先生用） -->
+      <div id="section_provisional_confirm_not_attending_teacher" class="mail-section d-none">
+        <div class="card mb-4">
+          <div class="card-header fw-bold bg-light">
+            <i class="bi bi-check-circle me-1"></i>仮出欠 送信完了メール（不参加・先生用）
+          </div>
+          <div class="card-body">
+            <div class="mb-3">
+              <label class="form-label fw-bold">件名</label>
+              <input type="text" class="form-control" name="mail_provisional_confirm_not_attending_subject_teacher"
+                     value="{{ settings.get('mail_provisional_confirm_not_attending_subject_teacher', '') }}">
+            </div>
+            <div class="mb-0">
+              <label class="form-label fw-bold">本文</label>
+              <textarea class="form-control font-monospace auto-resize" name="mail_provisional_confirm_not_attending_body_teacher">{{ settings.get('mail_provisional_confirm_not_attending_body_teacher', '') }}</textarea>
               <div class="form-text">追加変数: <code>{status}</code> 回答内容、<code>{provisional_url}</code> 変更用URL</div>
             </div>
           </div>
@@ -201,6 +264,27 @@
             <div class="mb-0">
               <label class="form-label fw-bold">本文</label>
               <textarea class="form-control font-monospace auto-resize" name="mail_final_confirm_attending_body">{{ settings.get('mail_final_confirm_attending_body', '') }}</textarea>
+              <div class="form-text">追加変数: <code>{status}</code> 回答内容、<code>{final_url}</code> 変更用URL、振込情報各変数</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 本出欠送信完了（参加・先生用） -->
+      <div id="section_final_confirm_attending_teacher" class="mail-section d-none">
+        <div class="card mb-4">
+          <div class="card-header fw-bold bg-light">
+            <i class="bi bi-check-circle me-1"></i>本出欠 送信完了メール（参加・先生用）
+          </div>
+          <div class="card-body">
+            <div class="mb-3">
+              <label class="form-label fw-bold">件名</label>
+              <input type="text" class="form-control" name="mail_final_confirm_attending_subject_teacher"
+                     value="{{ settings.get('mail_final_confirm_attending_subject_teacher', '') }}">
+            </div>
+            <div class="mb-0">
+              <label class="form-label fw-bold">本文</label>
+              <textarea class="form-control font-monospace auto-resize" name="mail_final_confirm_attending_body_teacher">{{ settings.get('mail_final_confirm_attending_body_teacher', '') }}</textarea>
               <div class="form-text">追加変数: <code>{status}</code> 回答内容、<code>{final_url}</code> 変更用URL、振込情報各変数</div>
             </div>
           </div>
@@ -288,6 +372,27 @@
         </div>
       </div>
 
+      <!-- 本出欠送信完了（不参加・先生用） -->
+      <div id="section_final_confirm_not_attending_teacher" class="mail-section d-none">
+        <div class="card mb-4">
+          <div class="card-header fw-bold bg-light">
+            <i class="bi bi-check-circle me-1"></i>本出欠 送信完了メール（不参加・先生用）
+          </div>
+          <div class="card-body">
+            <div class="mb-3">
+              <label class="form-label fw-bold">件名</label>
+              <input type="text" class="form-control" name="mail_final_confirm_not_attending_subject_teacher"
+                     value="{{ settings.get('mail_final_confirm_not_attending_subject_teacher', '') }}">
+            </div>
+            <div class="mb-0">
+              <label class="form-label fw-bold">本文</label>
+              <textarea class="form-control font-monospace auto-resize" name="mail_final_confirm_not_attending_body_teacher">{{ settings.get('mail_final_confirm_not_attending_body_teacher', '') }}</textarea>
+              <div class="form-text">追加変数: <code>{status}</code> 回答内容、<code>{final_url}</code> 変更用URL</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <!-- 最終リマインド -->
       <div id="section_final_reminder" class="mail-section d-none">
         <div class="card mb-4">
@@ -338,8 +443,12 @@
 
 <script>
 document.addEventListener('DOMContentLoaded', function () {
-  const HAS_TEACHER = ['final_url', 'reminder', 'final_reminder'];
-  const NO_SECTION_PREFIX = ['provisional_confirm_attending', 'provisional_confirm_not_attending', 'provisional_confirm_undecided', 'final_confirm_attending', 'final_confirm_not_attending'];
+  const HAS_TEACHER = [
+    'provisional_confirm_attending', 'provisional_confirm_not_attending', 'provisional_confirm_undecided',
+    'final_url', 'reminder',
+    'final_confirm_attending', 'final_confirm_not_attending',
+    'final_reminder',
+  ];
 
   function autoResize(ta) {
     ta.style.height = 'auto';


### PR DESCRIPTION
- 全5種のステータス別確認メールに先生用テンプレートを追加（計10キー）
- 編集画面の生徒/先生ラジオボタンをすべてのメール種別に対応
- _build関数にrole引数を追加し先生ロールで自動切り替え