### PR TITLE
HTML/テキスト形式切替をメール送信全経路に伝播

### DIFF
--- a/reunion/routes/admin.py
+++ b/reunion/routes/admin.py
@@ -670,10 +670,11 @@ def send_final_url_single(participant_id):
 
     base_url = current_app.config.get("APP_BASE_URL", "http://localhost:5000")
     final_url = generate_final_url(participant, base_url)
+    use_html = request.form.get("mail_format", "html") != "text"
 
     try:
         # current_app.config_obj はapp.pyで設定する簡易オブジェクト
-        log = send_final_url(participant, final_url)
+        log = send_final_url(participant, final_url, use_html=use_html)
         if log.status == "simulated":
             flash(f"[開発モード] {participant.name} へのメール内容をコンソールに出力しました。", "info")
         else:
@@ -720,6 +721,7 @@ def send_final_url_bulk():
     daily_limit = get_daily_send_limit()
     stage = (get_today_sent_count() // daily_limit) + 1 if daily_limit > 0 else 1
 
+    use_html = request.form.get("mail_format", "html") != "text"
     app = current_app._get_current_object()
     jobs = [(p.id, generate_final_url(p, base_url)) for p in batch]
 
@@ -732,7 +734,7 @@ def send_final_url_bulk():
                 if p is None:
                     continue
                 try:
-                    send_final_url(p, final_url)
+                    send_final_url(p, final_url, use_html=use_html)
                     sent += 1
                 except Exception as e:
                     logger.error(f"一括送信失敗: {p.email} - {e}", exc_info=True)
@@ -761,9 +763,10 @@ def send_reminder_single(participant_id):
 
     base_url = current_app.config.get("APP_BASE_URL", "http://localhost:5000")
     final_url = generate_final_url(participant, base_url)
+    use_html = request.form.get("mail_format", "html") != "text"
 
     try:
-        log = send_reminder(participant, final_url)
+        log = send_reminder(participant, final_url, use_html=use_html)
         if log.status == "simulated":
             flash(f"[開発モード] {participant.name} へのリマインド内容をコンソールに出力しました。", "info")
         else:
@@ -786,9 +789,10 @@ def send_final_reminder_single(participant_id):
     s = AppSetting.query.filter_by(key="reunion_guide_pdf").first()
     if s and s.value and os.path.isfile(s.value):
         pdf_path = s.value
+    use_html = request.form.get("mail_format", "html") != "text"
 
     try:
-        log = send_final_reminder(participant, attachment_path=pdf_path)
+        log = send_final_reminder(participant, attachment_path=pdf_path, use_html=use_html)
         if log.status == "simulated":
             flash(f"[開発モード] {participant.name} への最終リマインド内容をコンソールに出力しました。", "info")
         else:
@@ -826,6 +830,7 @@ def send_reminder_bulk():
         return redirect(url_for("admin.participants"))
 
     batch = targets[:remaining]
+    use_html = request.form.get("mail_format", "html") != "text"
     app = current_app._get_current_object()
     jobs = [(p.id, generate_final_url(p, base_url)) for p in batch]
 
@@ -838,7 +843,7 @@ def send_reminder_bulk():
                 if p is None:
                     continue
                 try:
-                    send_reminder(p, final_url)
+                    send_reminder(p, final_url, use_html=use_html)
                     sent += 1
                 except Exception as e:
                     logger.error(f"リマインド一括送信失敗: {p.email} - {e}", exc_info=True)
@@ -900,6 +905,7 @@ def send_final_reminder_bulk():
         if os.path.isfile(default_pdf):
             pdf_path = default_pdf
 
+    use_html = request.form.get("mail_format", "html") != "text"
     app = current_app._get_current_object()
     jobs = [p.id for p in batch]
 
@@ -912,7 +918,7 @@ def send_final_reminder_bulk():
                 if p is None:
                     continue
                 try:
-                    send_final_reminder(p, attachment_path=pdf_path)
+                    send_final_reminder(p, attachment_path=pdf_path, use_html=use_html)
                     sent += 1
                 except Exception as e:
                     logger.error(f"最終リマインド一括送信失敗: {p.email} - {e}", exc_info=True)

--- a/reunion/services/mail_service.py
+++ b/reunion/services/mail_service.py
@@ -697,20 +697,43 @@ def _send_smtp_cfg(to_email: str, subject: str, body: str, cfg: dict, attachment
         server.sendmail(cfg["from_addr"], [to_email], msg.as_string())
 
 
-def _send_brevo(to_email: str, subject: str, body: str, cfg: dict) -> None:
+def _send_smtp_text(to_email: str, subject: str, body: str, cfg: dict, attachment_path: str = None) -> None:
+    """SMTPでプレーンテキストのみ送信する"""
+    msg = MIMEMultipart("mixed")
+    msg["Subject"] = subject
+    msg["From"] = f"{cfg['from_name']} <{cfg['from_addr']}>"
+    msg["To"] = to_email
+    msg["Reply-To"] = cfg["from_addr"]
+    msg.attach(MIMEText(body, "plain", "utf-8"))
+    if attachment_path and os.path.isfile(attachment_path):
+        with open(attachment_path, "rb") as f:
+            attach = MIMEBase("application", "octet-stream")
+            attach.set_payload(f.read())
+        encoders.encode_base64(attach)
+        attach.add_header("Content-Disposition", "attachment", filename=os.path.basename(attachment_path))
+        msg.attach(attach)
+    with smtplib.SMTP(cfg["smtp_host"], cfg["smtp_port"]) as server:
+        server.ehlo(); server.starttls()
+        server.login(cfg["smtp_user"], cfg["smtp_password"])
+        server.sendmail(cfg["from_addr"], [to_email], msg.as_string())
+
+
+def _send_brevo(to_email: str, subject: str, body: str, cfg: dict, use_html: bool = True) -> None:
     """Brevo Transactional Email APIでメールを送信する"""
     api_key = cfg.get("brevo_api_key", "") or os.environ.get("BREVO_API_KEY", "") or current_app.config.get("BREVO_API_KEY", "")
     if not api_key:
         raise ValueError("BREVO_API_KEY が設定されていません")
 
-    payload = json.dumps({
+    data = {
         "sender":      {"name": cfg["from_name"], "email": cfg["from_addr"]},
         "to":          [{"email": to_email}],
         "replyTo":     {"email": cfg["from_addr"]},
         "subject":     subject,
-        "htmlContent": _text_to_html(body),
         "textContent": body,
-    }).encode("utf-8")
+    }
+    if use_html:
+        data["htmlContent"] = _text_to_html(body)
+    payload = json.dumps(data).encode("utf-8")
 
     req = urllib.request.Request(
         "https://api.brevo.com/v3/smtp/email",
@@ -758,7 +781,7 @@ def _get_mail_config():
     }
 
 
-def _dispatch_send(to_email: str, subject: str, body: str, mail_cfg: dict, attachment_path: str = None) -> str:
+def _dispatch_send(to_email: str, subject: str, body: str, mail_cfg: dict, attachment_path: str = None, use_html: bool = True) -> str:
     """モードに応じてメール送信し、ステータス文字列を返す"""
     from_addr = mail_cfg.get("from_addr", "")
     if from_addr:
@@ -768,10 +791,13 @@ def _dispatch_send(to_email: str, subject: str, body: str, mail_cfg: dict, attac
         _send_gas(to_email, subject, body, mail_cfg["from_name"])
         return "sent"
     elif mode == "smtp":
-        _send_smtp_cfg(to_email, subject, body, mail_cfg, attachment_path=attachment_path)
+        if use_html:
+            _send_smtp_cfg(to_email, subject, body, mail_cfg, attachment_path=attachment_path)
+        else:
+            _send_smtp_text(to_email, subject, body, mail_cfg, attachment_path=attachment_path)
         return "sent"
     elif mode == "brevo":
-        _send_brevo(to_email, subject, body, mail_cfg)
+        _send_brevo(to_email, subject, body, mail_cfg, use_html=use_html)
         return "sent"
     else:
         if attachment_path:
@@ -780,7 +806,7 @@ def _dispatch_send(to_email: str, subject: str, body: str, mail_cfg: dict, attac
         return "simulated"
 
 
-def send_final_url(participant, final_url: str) -> MailLog:
+def send_final_url(participant, final_url: str, use_html: bool = True) -> MailLog:
     """参加者に本出欠URLを送信する。"""
     mail_cfg = _get_mail_config()
     subject, body = _build_final_url_mail_body(participant.display_name, final_url, role=participant.role or "")
@@ -792,7 +818,7 @@ def send_final_url(participant, final_url: str) -> MailLog:
     )
 
     try:
-        log.status = _dispatch_send(participant.email, subject, body, mail_cfg)
+        log.status = _dispatch_send(participant.email, subject, body, mail_cfg, use_html=use_html)
         if log.status == "sent":
             logger.info(f"本出欠URL送信成功: {participant.email}")
         db.session.add(log)
@@ -991,7 +1017,7 @@ def send_final_confirmation(participant, status_label: str, final_url: str, stat
     return log
 
 
-def send_reminder(participant, final_url: str) -> MailLog:
+def send_reminder(participant, final_url: str, use_html: bool = True) -> MailLog:
     """参加者にリマインドメールを送信する。"""
     mail_cfg = _get_mail_config()
     subject, body = _build_reminder_mail_body(participant.display_name, final_url, role=participant.role or "")
@@ -1003,7 +1029,7 @@ def send_reminder(participant, final_url: str) -> MailLog:
     )
 
     try:
-        log.status = _dispatch_send(participant.email, subject, body, mail_cfg)
+        log.status = _dispatch_send(participant.email, subject, body, mail_cfg, use_html=use_html)
         if log.status == "sent":
             logger.info(f"リマインド送信成功: {participant.email}")
         db.session.add(log)
@@ -1046,7 +1072,7 @@ def _build_final_reminder_body(participant_name: str, role: str = "") -> tuple:
     return subject, body
 
 
-def send_final_reminder(participant, attachment_path: str = None) -> MailLog:
+def send_final_reminder(participant, attachment_path: str = None, use_html: bool = True) -> MailLog:
     """本出欠参加者に最終リマインドメール（PDF添付）を送信する。"""
     mail_cfg = _get_mail_config()
     subject, body = _build_final_reminder_body(participant.display_name, role=participant.role or "")
@@ -1059,7 +1085,7 @@ def send_final_reminder(participant, attachment_path: str = None) -> MailLog:
 
     try:
         log.status = _dispatch_send(participant.email, subject, body, mail_cfg,
-                                    attachment_path=attachment_path)
+                                    attachment_path=attachment_path, use_html=use_html)
         if log.status == "sent":
             logger.info(f"最終リマインド送信成功: {participant.email}")
         db.session.add(log)

--- a/reunion/templates/admin/mail_hub.html
+++ b/reunion/templates/admin/mail_hub.html
@@ -87,8 +87,14 @@
     <!-- メールプレビュー -->
     <div class="col-md-7">
       <div class="card border-0 shadow-sm">
-        <div class="card-header bg-light fw-bold">
-          <i class="bi bi-envelope-paper me-1"></i>メール内容プレビュー
+        <div class="card-header bg-light fw-bold d-flex align-items-center justify-content-between">
+          <span><i class="bi bi-envelope-paper me-1"></i>メール内容プレビュー</span>
+          <div class="btn-group btn-group-sm" role="group">
+            <input type="radio" class="btn-check" name="mailFormat" id="formatHtml" value="html" checked>
+            <label class="btn btn-outline-secondary" for="formatHtml">HTML</label>
+            <input type="radio" class="btn-check" name="mailFormat" id="formatText" value="text">
+            <label class="btn btn-outline-secondary" for="formatText">テキスト</label>
+          </div>
         </div>
         <div class="card-body">
           <div class="mb-3">
@@ -97,7 +103,8 @@
           </div>
           <div class="mb-3">
             <label class="form-label fw-bold text-muted small">本文</label>
-            <iframe id="previewBody" class="w-100 border rounded bg-light" style="min-height: 400px; font-size: 0.9rem;"></iframe>
+            <iframe id="previewBodyHtml" class="w-100 border rounded bg-light" style="min-height: 400px; font-size: 0.9rem;"></iframe>
+            <pre id="previewBodyText" class="form-control bg-light d-none" style="white-space: pre-wrap; min-height: 400px; font-size: 0.9rem;"></pre>
           </div>
           <div class="text-muted small">
             <i class="bi bi-info-circle me-1"></i>
@@ -145,6 +152,7 @@
               <span id="sendDescription"></span>
             </p>
             <form id="sendForm" method="POST">
+              <input type="hidden" name="mail_format" id="mailFormatInput" value="html">
               <button type="submit" class="btn btn-success btn-lg w-100" id="sendButton">
                 <i class="bi bi-send me-2"></i>
                 <span id="sendButtonText">送信する</span>
@@ -216,10 +224,11 @@ document.addEventListener('DOMContentLoaded', function() {
         loading.classList.add('d-none');
 
         document.getElementById('previewSubject').textContent = data.subject;
-        var iframe = document.getElementById('previewBody');
+        var iframe = document.getElementById('previewBodyHtml');
         var doc = iframe.contentDocument || iframe.contentWindow.document;
         doc.open(); doc.write(data.html_body); doc.close();
         iframe.style.height = Math.max(400, iframe.contentWindow.document.body.scrollHeight + 20) + 'px';
+        document.getElementById('previewBodyText').textContent = data.body;
 
         document.getElementById('targetCount').textContent = data.target_count;
         document.getElementById('remainingToday').textContent = data.remaining_today;
@@ -292,6 +301,16 @@ document.addEventListener('DOMContentLoaded', function() {
     // 先生トグルをリセット
     document.getElementById('toggleStudent').checked = true;
     loadPreview(this.value);
+  });
+
+  // テキスト/HTML切替
+  document.querySelectorAll('input[name="mailFormat"]').forEach(function(radio) {
+    radio.addEventListener('change', function() {
+      var isHtml = this.value === 'html';
+      document.getElementById('previewBodyHtml').classList.toggle('d-none', !isHtml);
+      document.getElementById('previewBodyText').classList.toggle('d-none', isHtml);
+      document.getElementById('mailFormatInput').value = this.value;
+    });
   });
 
   // URLパラメータ ?type=XXX があれば自動選択


### PR DESCRIPTION
- send_reminder, send_final_reminder に use_html パラメータを追加
- 一括・個別送信の全エンドポイント（6か所）で mail_format POST パラメータを読み取り use_html を渡す
- バックグラウンドスレッド内でも use_html がクロージャ経由で正しく参照される