### PR TITLE
ダッシュボードにフォームロック手動トグルを追加

### DIFF
--- a/reunion/routes/admin.py
+++ b/reunion/routes/admin.py
@@ -131,7 +131,40 @@ def index():
         "remaining_today": remaining_today,
         "send_stage": send_stage,
     }
-    return render_template("admin/index.html", stats=stats)
+    def _form_locked(key):
+        s = AppSetting.query.filter_by(key=key).first()
+        return s.value == "1" if s else False
+
+    locks = {
+        "provisional": _form_locked("provisional_form_locked"),
+        "final": _form_locked("final_form_locked"),
+    }
+    return render_template("admin/index.html", stats=stats, locks=locks)
+
+
+@admin_bp.route("/toggle-form-lock/<form_type>", methods=["POST"])
+def toggle_form_lock(form_type):
+    """仮出欠・本出欠フォームのロックを手動切替"""
+    if form_type not in ("provisional", "final"):
+        flash("不正なフォーム種別です。", "danger")
+        return redirect(url_for("admin.index"))
+    key = f"{form_type}_form_locked"
+    s = AppSetting.query.filter_by(key=key).first()
+    current = s.value == "1" if s else False
+    new_val = "0" if current else "1"
+    if s:
+        s.value = new_val
+        s.updated_at = datetime.utcnow()
+    else:
+        db.session.add(AppSetting(key=key, value=new_val))
+    db.session.commit()
+    if request.headers.get("X-Requested-With") == "XMLHttpRequest":
+        from flask import make_response
+        return make_response("", 204)
+    label = "仮出欠" if form_type == "provisional" else "本出欠"
+    state = "ロック" if new_val == "1" else "解除"
+    flash(f"{label}フォームを{state}しました。", "success" if new_val == "0" else "warning")
+    return redirect(url_for("admin.index"))
 
 
 # -----------------------------------------------

--- a/reunion/routes/forms.py
+++ b/reunion/routes/forms.py
@@ -222,7 +222,10 @@ def _today_jst():
 
 
 def _is_provisional_form_locked() -> bool:
-    """provisional_deadline の翌日以降（JST）はフォームをロックする。未設定ならロックしない。"""
+    """手動ロック設定を優先し、なければ provisional_deadline 翌日以降（JST）でロック。"""
+    manual = AppSetting.query.filter_by(key="provisional_form_locked").first()
+    if manual:
+        return manual.value == "1"
     s = AppSetting.query.filter_by(key="provisional_deadline").first()
     if not (s and s.value):
         return False
@@ -234,7 +237,10 @@ def _is_provisional_form_locked() -> bool:
 
 
 def _is_final_form_locked() -> bool:
-    """final_deadline の翌日以降（JST）はフォームをロックする。未設定ならロックしない。"""
+    """手動ロック設定を優先し、なければ final_deadline 翌日以降（JST）でロック。"""
+    manual = AppSetting.query.filter_by(key="final_form_locked").first()
+    if manual:
+        return manual.value == "1"
     s = AppSetting.query.filter_by(key="final_deadline").first()
     if not (s and s.value):
         return False

--- a/reunion/templates/admin/index.html
+++ b/reunion/templates/admin/index.html
@@ -19,6 +19,21 @@
   .mail-stat-row .mail-val { font-size: 1.1rem; font-weight: 600; }
   .card-hover { transition: transform 0.15s, box-shadow 0.15s; cursor: pointer; }
   .card-hover:hover { transform: translateY(-2px); box-shadow: 0 .5rem 1rem rgba(0,0,0,.12) !important; }
+  .apple-toggle {
+    position: relative; width: 51px; height: 31px; border-radius: 16px;
+    background: #e5e5ea; cursor: pointer;
+    transition: background 0.25s cubic-bezier(.4,0,.2,1);
+    flex-shrink: 0;
+  }
+  .apple-toggle.active { background: #34c759; }
+  .apple-toggle-knob {
+    position: absolute; top: 2px; left: 2px;
+    width: 27px; height: 27px; border-radius: 50%;
+    background: #fff;
+    box-shadow: 0 2px 6px rgba(0,0,0,.22), 0 0.5px 1px rgba(0,0,0,.12);
+    transition: transform 0.25s cubic-bezier(.4,0,.2,1);
+  }
+  .apple-toggle.active .apple-toggle-knob { transform: translateX(20px); }
 </style>
 {% endblock %}
 
@@ -171,6 +186,49 @@
   </div>
 </div>
 
+<!-- フォームロック管理 -->
+<div class="row g-4 mb-4">
+  <div class="col-12">
+    <div class="card border-0 shadow-sm">
+      <div class="card-body">
+        <h6 class="text-muted mb-3"><i class="bi bi-lock me-2"></i>フォームロック管理</h6>
+        <div class="row g-3">
+          <div class="col-md-6">
+            <div class="d-flex align-items-center justify-content-between p-3 rounded bg-light">
+              <div>
+                <div class="fw-bold">仮出欠フォーム</div>
+                <div class="small" id="label-provisional">
+                  {% if locks.provisional %}<span class="text-danger"><i class="bi bi-lock-fill me-1"></i>ロック中</span>{% else %}<span class="text-success"><i class="bi bi-unlock-fill me-1"></i>受付中</span>{% endif %}
+                </div>
+              </div>
+              <div class="apple-toggle {% if not locks.provisional %}active{% endif %}" id="toggle-provisional"
+                   data-url="{{ url_for('admin.toggle_form_lock', form_type='provisional') }}"
+                   data-target="provisional">
+                <div class="apple-toggle-knob"></div>
+              </div>
+            </div>
+          </div>
+          <div class="col-md-6">
+            <div class="d-flex align-items-center justify-content-between p-3 rounded bg-light">
+              <div>
+                <div class="fw-bold">本出欠フォーム</div>
+                <div class="small" id="label-final">
+                  {% if locks.final %}<span class="text-danger"><i class="bi bi-lock-fill me-1"></i>ロック中</span>{% else %}<span class="text-success"><i class="bi bi-unlock-fill me-1"></i>受付中</span>{% endif %}
+                </div>
+              </div>
+              <div class="apple-toggle {% if not locks.final %}active{% endif %}" id="toggle-final"
+                   data-url="{{ url_for('admin.toggle_form_lock', form_type='final') }}"
+                   data-target="final">
+                <div class="apple-toggle-knob"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- クイックアクション -->
 <h6 class="text-muted mb-2">クイックアクション</h6>
 <div class="row g-3 mb-4">
@@ -314,6 +372,25 @@
     { label: '未入金',   value: {{ stats.unpaid }}, color: '#dc3545', url: URLS.payments + '?status=unpaid' }
   ]);
 })();
+
+  // フォームロックトグル
+  document.querySelectorAll('.apple-toggle[data-url]').forEach(function(el) {
+    el.addEventListener('click', function() {
+      var url = el.dataset.url;
+      var target = el.dataset.target;
+      el.style.pointerEvents = 'none';
+      fetch(url, { method: 'POST', headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+        .then(function() {
+          var isActive = el.classList.toggle('active');
+          var label = document.getElementById('label-' + target);
+          label.innerHTML = isActive
+            ? '<span class="text-success"><i class="bi bi-unlock-fill me-1"></i>受付中</span>'
+            : '<span class="text-danger"><i class="bi bi-lock-fill me-1"></i>ロック中</span>';
+          el.style.pointerEvents = '';
+        })
+        .catch(function() { el.style.pointerEvents = ''; });
+    });
+  });
 
   // 自動送信プレビュー読み込み
   fetch("{{ url_for('admin.api_auto_send_preview') }}")


### PR DESCRIPTION
- 仮出欠・本出欠フォームのロック/解除をスライドボタンで切替
- fetch で非同期送信し、スクロール位置を維持したままUIを即時更新
- 手動ロック設定がある場合は日付ベースロックより優先