### PR TITLE
欠席連絡にモーダル確認と理由入力を追加

### DIFF
--- a/reunion/routes/forms.py
+++ b/reunion/routes/forms.py
@@ -307,10 +307,14 @@ def final(token):
     # ロック中の制御
     if locked:
         if can_cancel and request.form.get("status") == "cancelled":
-            # 直前キャンセルのみ受け付ける
+            cancel_reason = request.form.get("cancel_reason", "").strip()
+            if not cancel_reason:
+                flash("欠席の理由を入力してください。", "danger")
+                return redirect(url_for("forms.final", token=token))
             response = FinalResponse(
                 participant_id=participant.id,
                 status="cancelled",
+                remarks=cancel_reason,
                 submitted_at=datetime.utcnow(),
                 ip_address=request.remote_addr or "",
             )

--- a/reunion/templates/final_form.html
+++ b/reunion/templates/final_form.html
@@ -144,15 +144,51 @@
                     <div class="card-body text-center py-4">
                       <p class="mb-1">現在の回答: <strong class="text-success">参加</strong></p>
                       <p class="text-muted small mb-3">欠席される場合は、下のボタンで連絡してください。</p>
-                      <form method="POST" action="{{ url_for('forms.final', token=token) }}"
-                            onsubmit="return confirm('欠席のご連絡をします。よろしいですか？');">
-                        <input type="hidden" name="status" value="cancelled">
-                        <button type="submit" class="btn btn-danger btn-lg px-5">
-                          <i class="bi bi-x-circle me-2"></i>欠席の連絡をする
-                        </button>
-                      </form>
+                      <button type="button" class="btn btn-danger btn-lg px-5"
+                              data-bs-toggle="modal" data-bs-target="#cancelModal">
+                        <i class="bi bi-x-circle me-2"></i>欠席の連絡をする
+                      </button>
                     </div>
                   </div>
+
+                  <!-- 欠席確認モーダル -->
+                  <div class="modal fade" id="cancelModal" tabindex="-1" data-bs-backdrop="static">
+                    <div class="modal-dialog">
+                      <div class="modal-content">
+                        <div class="modal-header bg-danger text-white">
+                          <h5 class="modal-title"><i class="bi bi-x-circle me-2"></i>欠席のご連絡</h5>
+                          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+                        </div>
+                        <form method="POST" action="{{ url_for('forms.final', token=token) }}">
+                          <input type="hidden" name="status" value="cancelled">
+                          <div class="modal-body">
+                            <div class="alert alert-warning small">
+                              <i class="bi bi-exclamation-triangle me-1"></i>
+                              送信後は取り消しできません。ご確認の上送信してください。
+                            </div>
+                            <div class="mb-3">
+                              <label class="form-label fw-bold">欠席の理由 <span class="text-danger">*</span></label>
+                              <textarea class="form-control" name="cancel_reason" id="cancelReason"
+                                        rows="4" placeholder="例：急な仕事のため、体調不良のため　など"
+                                        required maxlength="500"></textarea>
+                              <div class="form-text text-end"><span id="cancelReasonCount">0</span> / 500</div>
+                            </div>
+                          </div>
+                          <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">戻る</button>
+                            <button type="submit" class="btn btn-danger">
+                              <i class="bi bi-check-lg me-1"></i>欠席を確定する
+                            </button>
+                          </div>
+                        </form>
+                      </div>
+                    </div>
+                  </div>
+                  <script>
+                    document.getElementById('cancelReason').addEventListener('input', function() {
+                      document.getElementById('cancelReasonCount').textContent = this.value.length;
+                    });
+                  </script>
                 {% elif existing and existing.status == 'cancelled' %}
                   <div class="alert alert-secondary py-2 mb-3">
                     <i class="bi bi-check-circle me-1"></i>


### PR DESCRIPTION
- 欠席ボタン押下でモーダルを表示
- 理由（必須・500字以内）を入力してから確定
- 理由はremarksとしてFinalResponseに保存