### PR TITLE
メール送信をテキスト形式のみに統一（HTML削除）

### DIFF
--- a/reunion/routes/admin.py
+++ b/reunion/routes/admin.py
@@ -831,11 +831,10 @@ def send_final_url_single(participant_id):
 
     base_url = current_app.config.get("APP_BASE_URL", "http://localhost:5000")
     final_url = generate_final_url(participant, base_url)
-    use_html = request.form.get("mail_format", "text") != "text"
 
     try:
         # current_app.config_obj はapp.pyで設定する簡易オブジェクト
-        log = send_final_url(participant, final_url, use_html=use_html)
+        log = send_final_url(participant, final_url)
         if log.status == "simulated":
             flash(f"[開発モード] {participant.name} へのメール内容をコンソールに出力しました。", "info")
         else:
@@ -882,7 +881,6 @@ def send_final_url_bulk():
     daily_limit = get_daily_send_limit()
     stage = (get_today_sent_count() // daily_limit) + 1 if daily_limit > 0 else 1
 
-    use_html = request.form.get("mail_format", "text") != "text"
     app = current_app._get_current_object()
     jobs = [(p.id, generate_final_url(p, base_url)) for p in batch]
 
@@ -895,7 +893,7 @@ def send_final_url_bulk():
                 if p is None:
                     continue
                 try:
-                    send_final_url(p, final_url, use_html=use_html)
+                    send_final_url(p, final_url)
                     sent += 1
                 except Exception as e:
                     logger.error(f"一括送信失敗: {p.email} - {e}", exc_info=True)
@@ -924,10 +922,9 @@ def send_reminder_single(participant_id):
 
     base_url = current_app.config.get("APP_BASE_URL", "http://localhost:5000")
     final_url = generate_final_url(participant, base_url)
-    use_html = request.form.get("mail_format", "text") != "text"
 
     try:
-        log = send_reminder(participant, final_url, use_html=use_html)
+        log = send_reminder(participant, final_url)
         if log.status == "simulated":
             flash(f"[開発モード] {participant.name} へのリマインド内容をコンソールに出力しました。", "info")
         else:
@@ -950,10 +947,9 @@ def send_final_reminder_single(participant_id):
     s = AppSetting.query.filter_by(key="reunion_guide_pdf").first()
     if s and s.value and os.path.isfile(s.value):
         pdf_path = s.value
-    use_html = request.form.get("mail_format", "text") != "text"
 
     try:
-        log = send_final_reminder(participant, attachment_path=pdf_path, use_html=use_html)
+        log = send_final_reminder(participant, attachment_path=pdf_path)
         if log.status == "simulated":
             flash(f"[開発モード] {participant.name} への最終リマインド内容をコンソールに出力しました。", "info")
         else:
@@ -981,10 +977,9 @@ def send_unlock_notice_single(participant_id):
     deadline_date = datetime.utcnow() + timedelta(hours=9) + timedelta(weeks=1)
     deadline_str = f"{deadline_date.month}月{deadline_date.day}日"
 
-    use_html = request.form.get("mail_format", "text") != "text"
 
     try:
-        log = send_unlock_notice(participant, final_url, deadline_str, use_html=use_html)
+        log = send_unlock_notice(participant, final_url, deadline_str)
         if log.status == "simulated":
             flash(f"[開発モード] {participant.name} へのロック解除通知をコンソールに出力しました。", "info")
         else:
@@ -1022,7 +1017,6 @@ def send_reminder_bulk():
         return redirect(url_for("admin.participants"))
 
     batch = targets[:remaining]
-    use_html = request.form.get("mail_format", "text") != "text"
     app = current_app._get_current_object()
     jobs = [(p.id, generate_final_url(p, base_url)) for p in batch]
 
@@ -1035,7 +1029,7 @@ def send_reminder_bulk():
                 if p is None:
                     continue
                 try:
-                    send_reminder(p, final_url, use_html=use_html)
+                    send_reminder(p, final_url)
                     sent += 1
                 except Exception as e:
                     logger.error(f"リマインド一括送信失敗: {p.email} - {e}", exc_info=True)
@@ -1097,7 +1091,6 @@ def send_final_reminder_bulk():
         if os.path.isfile(default_pdf):
             pdf_path = default_pdf
 
-    use_html = request.form.get("mail_format", "text") != "text"
     app = current_app._get_current_object()
     jobs = [p.id for p in batch]
 
@@ -1110,7 +1103,7 @@ def send_final_reminder_bulk():
                 if p is None:
                     continue
                 try:
-                    send_final_reminder(p, attachment_path=pdf_path, use_html=use_html)
+                    send_final_reminder(p, attachment_path=pdf_path)
                     sent += 1
                 except Exception as e:
                     logger.error(f"最終リマインド一括送信失敗: {p.email} - {e}", exc_info=True)

--- a/reunion/services/mail_service.py
+++ b/reunion/services/mail_service.py
@@ -790,8 +790,8 @@ def _send_smtp_text(to_email: str, subject: str, body: str, cfg: dict, attachmen
         server.sendmail(cfg["from_addr"], [to_email], msg.as_string())
 
 
-def _send_brevo(to_email: str, subject: str, body: str, cfg: dict, use_html: bool = True, attachment_path: str = None) -> None:
-    """Brevo Transactional Email APIでメールを送信する"""
+def _send_brevo(to_email: str, subject: str, body: str, cfg: dict, attachment_path: str = None) -> None:
+    """Brevo Transactional Email APIでメールを送信する（テキスト形式）"""
     import base64
     api_key = cfg.get("brevo_api_key", "") or os.environ.get("BREVO_API_KEY", "") or current_app.config.get("BREVO_API_KEY", "")
     if not api_key:
@@ -804,8 +804,6 @@ def _send_brevo(to_email: str, subject: str, body: str, cfg: dict, use_html: boo
         "subject":     subject,
         "textContent": body,
     }
-    if use_html:
-        data["htmlContent"] = _text_to_html(body)
     if attachment_path and os.path.isfile(attachment_path):
         with open(attachment_path, "rb") as f:
             encoded = base64.b64encode(f.read()).decode("utf-8")
@@ -858,8 +856,8 @@ def _get_mail_config():
     }
 
 
-def _dispatch_send(to_email: str, subject: str, body: str, mail_cfg: dict, attachment_path: str = None, use_html: bool = True) -> str:
-    """モードに応じてメール送信し、ステータス文字列を返す"""
+def _dispatch_send(to_email: str, subject: str, body: str, mail_cfg: dict, attachment_path: str = None) -> str:
+    """モードに応じてメール送信し、ステータス文字列を返す（テキスト形式固定）"""
     from_addr = mail_cfg.get("from_addr", "")
     if from_addr:
         body = body.rstrip("\n") + f"\nE-mail: {from_addr}\n"
@@ -868,13 +866,10 @@ def _dispatch_send(to_email: str, subject: str, body: str, mail_cfg: dict, attac
         _send_gas(to_email, subject, body, mail_cfg["from_name"])
         return "sent"
     elif mode == "smtp":
-        if use_html:
-            _send_smtp_cfg(to_email, subject, body, mail_cfg, attachment_path=attachment_path)
-        else:
-            _send_smtp_text(to_email, subject, body, mail_cfg, attachment_path=attachment_path)
+        _send_smtp_text(to_email, subject, body, mail_cfg, attachment_path=attachment_path)
         return "sent"
     elif mode == "brevo":
-        _send_brevo(to_email, subject, body, mail_cfg, use_html=use_html, attachment_path=attachment_path)
+        _send_brevo(to_email, subject, body, mail_cfg, attachment_path=attachment_path)
         return "sent"
     else:
         if attachment_path:
@@ -883,7 +878,7 @@ def _dispatch_send(to_email: str, subject: str, body: str, mail_cfg: dict, attac
         return "simulated"
 
 
-def send_final_url(participant, final_url: str, use_html: bool = True) -> MailLog:
+def send_final_url(participant, final_url: str) -> MailLog:
     """参加者に本出欠URLを送信する。"""
     mail_cfg = _get_mail_config()
     subject, body = _build_final_url_mail_body(participant.display_name, final_url, role=participant.role or "")
@@ -895,7 +890,7 @@ def send_final_url(participant, final_url: str, use_html: bool = True) -> MailLo
     )
 
     try:
-        log.status = _dispatch_send(participant.email, subject, body, mail_cfg, use_html=use_html)
+        log.status = _dispatch_send(participant.email, subject, body, mail_cfg)
         if log.status == "sent":
             logger.info(f"本出欠URL送信成功: {participant.email}")
         db.session.add(log)
@@ -1094,7 +1089,7 @@ def send_final_confirmation(participant, status_label: str, final_url: str, stat
     return log
 
 
-def send_reminder(participant, final_url: str, use_html: bool = True) -> MailLog:
+def send_reminder(participant, final_url: str) -> MailLog:
     """参加者にリマインドメールを送信する。"""
     mail_cfg = _get_mail_config()
     subject, body = _build_reminder_mail_body(participant.display_name, final_url, role=participant.role or "")
@@ -1106,7 +1101,7 @@ def send_reminder(participant, final_url: str, use_html: bool = True) -> MailLog
     )
 
     try:
-        log.status = _dispatch_send(participant.email, subject, body, mail_cfg, use_html=use_html)
+        log.status = _dispatch_send(participant.email, subject, body, mail_cfg)
         if log.status == "sent":
             logger.info(f"リマインド送信成功: {participant.email}")
         db.session.add(log)
@@ -1149,7 +1144,7 @@ def _build_final_reminder_body(participant_name: str, role: str = "", final_url:
     return subject, body
 
 
-def send_final_reminder(participant, attachment_path: str = None, use_html: bool = True) -> MailLog:
+def send_final_reminder(participant, attachment_path: str = None) -> MailLog:
     """本出欠参加者に最終リマインドメール（PDF添付）を送信する。"""
     from flask import current_app
     from services.token_service import ensure_token
@@ -1167,7 +1162,7 @@ def send_final_reminder(participant, attachment_path: str = None, use_html: bool
 
     try:
         log.status = _dispatch_send(participant.email, subject, body, mail_cfg,
-                                    attachment_path=attachment_path, use_html=use_html)
+                                    attachment_path=attachment_path)
         if log.status == "sent":
             logger.info(f"最終リマインド送信成功: {participant.email}")
         db.session.add(log)
@@ -1248,7 +1243,7 @@ def send_cancel_confirmation(participant, cancel_reason: str) -> MailLog:
     return log
 
 
-def send_unlock_notice(participant, final_url: str, deadline_str: str, use_html: bool = True) -> MailLog:
+def send_unlock_notice(participant, final_url: str, deadline_str: str) -> MailLog:
     """フォームロック解除通知メールを送信する。deadline_str は 'M月D日' 形式。"""
     mail_cfg = _get_mail_config()
     reunion = _get_reunion_info()
@@ -1272,7 +1267,7 @@ def send_unlock_notice(participant, final_url: str, deadline_str: str, use_html:
         sent_at=datetime.utcnow(),
     )
     try:
-        log.status = _dispatch_send(participant.email, subject, body, mail_cfg, use_html=use_html)
+        log.status = _dispatch_send(participant.email, subject, body, mail_cfg)
         if log.status == "sent":
             logger.info(f"ロック解除通知送信成功: {participant.email}")
         db.session.add(log)

--- a/reunion/templates/admin/mail_hub.html
+++ b/reunion/templates/admin/mail_hub.html
@@ -88,14 +88,8 @@
     <!-- メールプレビュー -->
     <div class="col-md-7">
       <div class="card border-0 shadow-sm">
-        <div class="card-header bg-light fw-bold d-flex align-items-center justify-content-between">
-          <span><i class="bi bi-envelope-paper me-1"></i>メール内容プレビュー</span>
-          <div class="btn-group btn-group-sm" role="group">
-            <input type="radio" class="btn-check" name="mailFormat" id="formatHtml" value="html">
-            <label class="btn btn-outline-secondary" for="formatHtml">HTML</label>
-            <input type="radio" class="btn-check" name="mailFormat" id="formatText" value="text" checked>
-            <label class="btn btn-outline-secondary" for="formatText">テキスト</label>
-          </div>
+        <div class="card-header bg-light fw-bold">
+          <i class="bi bi-envelope-paper me-1"></i>メール内容プレビュー
         </div>
         <div class="card-body">
           <div class="mb-3">
@@ -114,7 +108,6 @@
           </div>
           <div class="mb-3">
             <label class="form-label fw-bold text-muted small">本文</label>
-            <iframe id="previewBodyHtml" class="w-100 border rounded bg-light d-none" style="min-height: 400px; font-size: 0.9rem;"></iframe>
             <pre id="previewBodyText" class="form-control bg-light" style="white-space: pre-wrap; min-height: 400px; font-size: 0.9rem;"></pre>
           </div>
           <div class="text-muted small">
@@ -163,7 +156,6 @@
               <span id="sendDescription"></span>
             </p>
             <form id="sendForm" method="POST">
-              <input type="hidden" name="mail_format" id="mailFormatInput" value="text">
               <button type="submit" class="btn btn-success btn-lg w-100" id="sendButton">
                 <i class="bi bi-send me-2"></i>
                 <span id="sendButtonText">送信する</span>
@@ -330,16 +322,6 @@ document.addEventListener('DOMContentLoaded', function() {
     // 先生トグルをリセット
     document.getElementById('toggleStudent').checked = true;
     loadPreview(this.value);
-  });
-
-  // テキスト/HTML切替
-  document.querySelectorAll('input[name="mailFormat"]').forEach(function(radio) {
-    radio.addEventListener('change', function() {
-      var isHtml = this.value === 'html';
-      document.getElementById('previewBodyHtml').classList.toggle('d-none', !isHtml);
-      document.getElementById('previewBodyText').classList.toggle('d-none', isHtml);
-      document.getElementById('mailFormatInput').value = this.value;
-    });
   });
 
   // URLパラメータ ?type=XXX があれば自動選択

--- a/reunion/templates/admin/participant_detail.html
+++ b/reunion/templates/admin/participant_detail.html
@@ -277,23 +277,15 @@
           <div id="modalAttachment" class="d-none mb-2">
             <span class="badge bg-success"><i class="bi bi-paperclip me-1"></i>添付: <span id="modalAttachName"></span>（<span id="modalAttachSize"></span> KB）</span>
           </div>
-          <div class="mb-2 d-flex gap-2 align-items-center">
+          <div class="mb-2">
             <span class="text-muted small fw-bold">本文</span>
-            <div class="btn-group btn-group-sm ms-auto" role="group">
-              <input type="radio" class="btn-check" name="modalFormat" id="modalFmtText" value="text" checked>
-              <label class="btn btn-outline-secondary" for="modalFmtText">テキスト</label>
-              <input type="radio" class="btn-check" name="modalFormat" id="modalFmtHtml" value="html">
-              <label class="btn btn-outline-secondary" for="modalFmtHtml">HTML</label>
-            </div>
           </div>
           <pre id="modalBodyText" class="form-control bg-light" style="white-space:pre-wrap; min-height:200px; font-size:0.85rem;"></pre>
-          <iframe id="modalBodyHtml" class="w-100 border rounded bg-light d-none" style="min-height:200px;"></iframe>
         </div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">キャンセル</button>
         <form id="modalSendForm" method="POST">
-          <input type="hidden" name="mail_format" id="modalFormatInput" value="text">
           <button type="submit" class="btn btn-primary" id="modalSendBtn">
             <i class="bi bi-send me-1"></i>送信する
           </button>
@@ -348,11 +340,6 @@ function openMailPreview(mailType) {
       document.getElementById('modalSubject').textContent = d.subject;
       document.getElementById('modalBodyText').textContent = d.body;
 
-      var iframe = document.getElementById('modalBodyHtml');
-      var doc = iframe.contentDocument || iframe.contentWindow.document;
-      doc.open(); doc.write(d.html_body); doc.close();
-      iframe.style.height = Math.max(200, iframe.contentWindow.document.body.scrollHeight + 20) + 'px';
-
       var att = document.getElementById('modalAttachment');
       if (d.attachment) {
         document.getElementById('modalAttachName').textContent = d.attachment.filename;
@@ -374,13 +361,5 @@ function openMailPreview(mailType) {
     });
 }
 
-document.querySelectorAll('input[name="modalFormat"]').forEach(function(r) {
-  r.addEventListener('change', function() {
-    var isHtml = this.value === 'html';
-    document.getElementById('modalBodyText').classList.toggle('d-none', isHtml);
-    document.getElementById('modalBodyHtml').classList.toggle('d-none', !isHtml);
-    document.getElementById('modalFormatInput').value = this.value;
-  });
-});
 </script>
 {% endblock %}


### PR DESCRIPTION
テキスト/HTML切替UIをmail_hub・参加者詳細モーダルから削除し、
mail_service・admin routesからHTML送信コードを除去。