### PR TITLE
名簿: 新氏名削除・幹事ロール追加・全列フィルター/ソート・全情報エクスポート

### DIFF
--- a/reunion/models.py
+++ b/reunion/models.py
@@ -21,15 +21,13 @@ class Participant(db.Model):
     __tablename__ = "participants"
 
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(100), nullable=False)          # 氏名（旧姓含む）
-    name_kana = db.Column(db.String(100), default="")         # 氏名カナ（旧姓）
-    new_name = db.Column(db.String(100), default="")          # 新氏名（旧姓と同じなら空）
-    new_name_kana = db.Column(db.String(100), default="")     # 新氏名カナ
+    name = db.Column(db.String(100), nullable=False)          # 氏名
+    name_kana = db.Column(db.String(100), default="")         # 氏名カナ
     email = db.Column(db.String(200), nullable=False, unique=True)  # メールアドレス（重複排除の基準）
     token = db.Column(db.String(64), unique=True, nullable=True)    # 本出欠フォームURL用トークン
     class_name = db.Column(db.String(50), default="")         # クラス（2桁数字: 31=3年1組、学年主任は空）
     student_number = db.Column(db.String(20), default="")     # 出席番号
-    # role: 生徒 / 教師 / 学年主任
+    # role: 生徒 / 教師 / 学年主任 / 幹事
     role = db.Column(db.String(20), default="生徒")
     notes = db.Column(db.Text, default="")                    # 参加者自身のメモ（備考）
     teacher_memo = db.Column(db.Text, default="")             # 幹事用メモ

--- a/reunion/routes/admin.py
+++ b/reunion/routes/admin.py
@@ -189,7 +189,6 @@ def participants():
         query = query.filter(
             db.or_(
                 Participant.name.ilike(f"%{q}%"),
-                Participant.new_name.ilike(f"%{q}%"),
                 Participant.email.ilike(f"%{q}%"),
             )
         )
@@ -205,7 +204,7 @@ def participants():
         return int(p.student_number) if p.student_number and p.student_number.isdigit() else 9999
 
     def _role_order(p):
-        return {"生徒": 0, "教師": 1, "学年主任": 2}.get(p.role, 3)
+        return {"生徒": 0, "教師": 1, "学年主任": 2, "幹事": 3}.get(p.role, 4)
 
     sort_key_map = {
         "class":   lambda p: (p.class_name or "", _role_order(p), _num(p)),
@@ -373,6 +372,26 @@ def update_memo(participant_id):
     participant.updated_at = datetime.utcnow()
     db.session.commit()
     flash("メモを更新しました。", "success")
+    return redirect(url_for("admin.participant_detail", participant_id=participant_id))
+
+
+@admin_bp.route("/participant/<int:participant_id>/update-role", methods=["POST"])
+def update_role(participant_id):
+    """役割を更新"""
+    participant = db.session.get(Participant, participant_id)
+    if participant is None:
+        flash("参加者が見つかりません。", "danger")
+        return redirect(url_for("admin.participants"))
+
+    role = request.form.get("role", "").strip()
+    if role not in {"生徒", "教師", "学年主任", "幹事"}:
+        flash("無効な役割です。", "danger")
+        return redirect(url_for("admin.participant_detail", participant_id=participant_id))
+
+    participant.role = role
+    participant.updated_at = datetime.utcnow()
+    db.session.commit()
+    flash(f"役割を「{role}」に変更しました。", "success")
     return redirect(url_for("admin.participant_detail", participant_id=participant_id))
 
 
@@ -1511,7 +1530,8 @@ def roster():
         (Participant.role == "生徒", 0),
         (Participant.role == "教師", 1),
         (Participant.role == "学年主任", 2),
-        else_=3,
+        (Participant.role == "幹事", 3),
+        else_=4,
     )
     participants = Participant.query.all()
 
@@ -1519,7 +1539,7 @@ def roster():
         return int(p.student_number) if p.student_number and p.student_number.isdigit() else 9999
 
     def _role_ord(p):
-        return {"生徒": 0, "教師": 1, "学年主任": 2}.get(p.role, 3)
+        return {"生徒": 0, "教師": 1, "学年主任": 2, "幹事": 3}.get(p.role, 4)
 
     participants.sort(key=lambda p: (p.class_name or "", _role_ord(p), _num(p)))
     return render_template("admin/roster.html", participants=participants)
@@ -1572,20 +1592,20 @@ def roster_import():
     # ヘッダー行の検出と列インデックスの解決
     NAME_HEADERS          = {"氏名", "名前", "name"}
     NAME_KANA_HEADERS     = {"氏名カナ", "氏名（カナ）", "フリガナ", "ふりがな", "kana", "name_kana"}
-    NEW_NAME_HEADERS      = {"新氏名", "新名前", "new_name"}
-    NEW_NAME_KANA_HEADERS = {"新氏名カナ", "新フリガナ", "new_name_kana"}
     EMAIL_HEADERS         = {"メールアドレス", "メール", "email", "mail"}
     CLASS_HEADERS         = {"クラス", "class", "組", "担当クラス"}
     NUMBER_HEADERS        = {"出席番号", "番号", "number", "no"}
     ROLE_HEADERS          = {"役割", "role", "種別", "区分"}
-    MEMO_HEADERS          = {"幹事メモ", "メモ", "memo", "備考"}
+    MEMO_HEADERS          = {"幹事メモ", "メモ", "memo"}
     TOKEN_HEADERS         = {"トークン", "token"}
     PROV_STATUS_HEADERS   = {"仮出欠", "provisional_status"}
     FINAL_STATUS_HEADERS  = {"本出欠", "final_status"}
     COMPANIONS_HEADERS    = {"同伴者数", "companions"}
     TRANSFER_NAME_HEADERS = {"振込名義", "transfer_name"}
+    REMARKS_HEADERS       = {"備考", "remarks", "本出欠備考"}
     PAY_STATUS_HEADERS    = {"入金ステータス", "payment_status"}
     PAID_AMOUNT_HEADERS   = {"入金金額", "paid_amount"}
+    EXPECTED_AMOUNT_HEADERS = {"支払予定金額", "expected_amount", "予定金額"}
     PAYMENT_DATE_HEADERS  = {"支払日", "payment_date"}
 
     first = [h.strip().lower() for h in rows[0]]
@@ -1600,8 +1620,6 @@ def roster_import():
 
         idx_name          = find_idx(NAME_HEADERS)
         idx_name_kana     = find_idx(NAME_KANA_HEADERS)
-        idx_new_name      = find_idx(NEW_NAME_HEADERS)
-        idx_new_name_kana = find_idx(NEW_NAME_KANA_HEADERS)
         idx_email         = find_idx(EMAIL_HEADERS)
         idx_class         = find_idx(CLASS_HEADERS)
         idx_number        = find_idx(NUMBER_HEADERS)
@@ -1611,16 +1629,19 @@ def roster_import():
         idx_prov_status   = find_idx(PROV_STATUS_HEADERS)
         idx_final_status  = find_idx(FINAL_STATUS_HEADERS)
         idx_companions    = find_idx(COMPANIONS_HEADERS)
-        idx_transfer_name = find_idx(TRANSFER_NAME_HEADERS)
-        idx_pay_status    = find_idx(PAY_STATUS_HEADERS)
-        idx_paid_amount   = find_idx(PAID_AMOUNT_HEADERS)
-        idx_payment_date  = find_idx(PAYMENT_DATE_HEADERS)
-        data_rows         = rows[1:]
+        idx_transfer_name    = find_idx(TRANSFER_NAME_HEADERS)
+        idx_remarks          = find_idx(REMARKS_HEADERS)
+        idx_pay_status       = find_idx(PAY_STATUS_HEADERS)
+        idx_paid_amount      = find_idx(PAID_AMOUNT_HEADERS)
+        idx_expected_amount  = find_idx(EXPECTED_AMOUNT_HEADERS)
+        idx_payment_date     = find_idx(PAYMENT_DATE_HEADERS)
+        data_rows            = rows[1:]
     else:
-        # ヘッダーなし → 固定順: 氏名, 氏名カナ, 新氏名, 新氏名カナ, メール, クラス, 出席番号, 役割, 幹事メモ
-        idx_name, idx_name_kana, idx_new_name, idx_new_name_kana, idx_email, idx_class, idx_number, idx_role, idx_memo = 0, 1, 2, 3, 4, 5, 6, 7, 8
+        # ヘッダーなし → 固定順: 氏名, 氏名カナ, メール, クラス, 出席番号, 役割, 幹事メモ
+        idx_name, idx_name_kana, idx_email, idx_class, idx_number, idx_role, idx_memo = 0, 1, 2, 3, 4, 5, 6
         idx_token = idx_prov_status = idx_final_status = None
-        idx_companions = idx_transfer_name = idx_pay_status = idx_paid_amount = idx_payment_date = None
+        idx_companions = idx_transfer_name = idx_remarks = None
+        idx_pay_status = idx_paid_amount = idx_expected_amount = idx_payment_date = None
         data_rows = rows
 
     if idx_name is None:
@@ -1633,7 +1654,7 @@ def roster_import():
         return ""
 
     # 有効な役割値
-    VALID_ROLES = {"生徒", "教師", "学年主任"}
+    VALID_ROLES = {"生徒", "教師", "学年主任", "幹事"}
 
     PROV_STATUS_MAP  = {"参加": "attending", "不参加": "not_attending", "未定": "undecided",
                         "attending": "attending", "not_attending": "not_attending", "undecided": "undecided"}
@@ -1654,8 +1675,6 @@ def roster_import():
 
         name          = get_col(row, idx_name)
         name_kana     = get_col(row, idx_name_kana)
-        new_name      = get_col(row, idx_new_name)
-        new_name_kana = get_col(row, idx_new_name_kana)
         email         = get_col(row, idx_email).lower()
         class_        = get_col(row, idx_class)
         number        = get_col(row, idx_number)
@@ -1667,9 +1686,12 @@ def roster_import():
         companions_raw = get_col(row, idx_companions)
         companions    = int(companions_raw) if companions_raw.isdigit() else 0
         transfer_name = normalize_transfer_name(get_col(row, idx_transfer_name))
+        remarks       = get_col(row, idx_remarks)
         pay_status    = PAY_STATUS_MAP.get(get_col(row, idx_pay_status), "")
         paid_raw      = get_col(row, idx_paid_amount)
         paid_amount   = int(paid_raw) if paid_raw.isdigit() else 0
+        expected_raw  = get_col(row, idx_expected_amount)
+        expected_amount = int(expected_raw) if expected_raw.isdigit() else 0
         pay_date_raw  = get_col(row, idx_payment_date)
         payment_date  = None
         if pay_date_raw:
@@ -1696,21 +1718,15 @@ def roster_import():
         if not email or "@" not in email:
             email = f"__no_email_{name}_{class_}_{role}@placeholder.local"
 
-        # 新氏名が旧氏名と同じなら空にする（表示時に重複を避けるため）
-        if new_name == name:
-            new_name = ""
-        if new_name_kana == name_kana:
-            new_name_kana = ""
-
         new_participants.append(dict(
             name=name, name_kana=name_kana,
-            new_name=new_name, new_name_kana=new_name_kana,
             email=email, class_name=class_,
             student_number=number, role=role, teacher_memo=memo,
             _token=token,
             _prov_status=prov_status, _final_status=final_status,
-            _companions=companions, _transfer_name=transfer_name,
-            _pay_status=pay_status, _paid_amount=paid_amount, _payment_date=payment_date,
+            _companions=companions, _transfer_name=transfer_name, _remarks=remarks,
+            _pay_status=pay_status, _paid_amount=paid_amount,
+            _expected_amount=expected_amount, _payment_date=payment_date,
         ))
 
     # 全テーブルをリセットして再登録
@@ -1724,14 +1740,16 @@ def roster_import():
     db.session.flush()
 
     for p_data in new_participants:
-        token         = p_data.pop("_token")
-        prov_status   = p_data.pop("_prov_status")
-        final_status  = p_data.pop("_final_status")
-        companions    = p_data.pop("_companions")
-        transfer_name = p_data.pop("_transfer_name")
-        pay_status    = p_data.pop("_pay_status")
-        paid_amount   = p_data.pop("_paid_amount")
-        payment_date  = p_data.pop("_payment_date")
+        token           = p_data.pop("_token")
+        prov_status     = p_data.pop("_prov_status")
+        final_status    = p_data.pop("_final_status")
+        companions      = p_data.pop("_companions")
+        transfer_name   = p_data.pop("_transfer_name")
+        remarks         = p_data.pop("_remarks")
+        pay_status      = p_data.pop("_pay_status")
+        paid_amount     = p_data.pop("_paid_amount")
+        expected_amount = p_data.pop("_expected_amount")
+        payment_date    = p_data.pop("_payment_date")
 
         p = Participant(**p_data)
         if token:
@@ -1746,11 +1764,13 @@ def roster_import():
             db.session.add(FinalResponse(
                 participant_id=p.id, status=final_status,
                 companions=companions, transfer_name=transfer_name,
+                remarks=remarks,
             ))
             db.session.add(Payment(
                 participant_id=p.id,
                 payment_status=pay_status or "unpaid",
                 paid_amount=paid_amount,
+                expected_amount=expected_amount,
                 payment_date=payment_date,
                 transfer_name=transfer_name,
             ))
@@ -1826,10 +1846,10 @@ def roster_export():
     writer = csv.writer(output)
 
     writer.writerow([
-        "氏名", "氏名（カナ）", "新氏名", "新氏名カナ",
+        "氏名", "氏名（カナ）",
         "メールアドレス", "クラス", "出席番号", "役割", "幹事メモ",
-        "トークン", "仮出欠", "本出欠", "同伴者数", "振込名義",
-        "入金ステータス", "入金金額", "支払日",
+        "トークン", "仮出欠", "本出欠", "同伴者数", "振込名義", "備考",
+        "入金ステータス", "入金金額", "支払予定金額", "支払日",
     ])
 
     PROV_LABELS  = {"attending": "参加", "not_attending": "不参加", "undecided": "未定"}
@@ -1844,8 +1864,6 @@ def roster_export():
         writer.writerow([
             p.name,
             p.name_kana or "",
-            p.new_name or "",
-            p.new_name_kana or "",
             email_out,
             p.class_name or "",
             p.student_number or "",
@@ -1856,8 +1874,10 @@ def roster_export():
             FINAL_LABELS.get(final.status, "")  if final else "",
             final.companions                    if final else "",
             final.transfer_name                 if final else "",
+            final.remarks                       if final else "",
             PAY_LABELS.get(pay.payment_status, "") if pay else "",
             pay.paid_amount                     if pay else "",
+            pay.expected_amount                 if pay else "",
             pay.payment_date.strftime("%Y-%m-%d") if (pay and pay.payment_date) else "",
         ])
 

--- a/reunion/templates/admin/participant_detail.html
+++ b/reunion/templates/admin/participant_detail.html
@@ -22,9 +22,6 @@
           <dt class="col-4">氏名</dt>
           <dd class="col-8">
             {{ participant.display_name }}
-            {% if participant.new_name %}
-              <br><span class="text-muted small">旧氏名: {{ participant.name }}</span>
-            {% endif %}
           </dd>
           <dt class="col-4">メール</dt><dd class="col-8">{{ participant.email }}</dd>
           <dt class="col-4">登録日時</dt>
@@ -202,9 +199,34 @@
     </div>
   </div>
 
+  <!-- 役割 -->
+  <div class="col-md-6">
+    <div class="card h-100">
+      <div class="card-header fw-bold bg-light">役割</div>
+      <div class="card-body">
+        <p class="mb-2">
+          現在:
+          {% if participant.role == '教師' %}<span class="badge bg-warning text-dark">教師</span>
+          {% elif participant.role == '学年主任' %}<span class="badge bg-danger">学年主任</span>
+          {% elif participant.role == '幹事' %}<span class="badge bg-info text-dark">幹事</span>
+          {% else %}<span class="badge bg-primary">生徒</span>{% endif %}
+        </p>
+        <form method="POST" action="{{ url_for('admin.update_role', participant_id=participant.id) }}" class="d-flex gap-2 align-items-center">
+          <select class="form-select form-select-sm" name="role" style="width:auto;">
+            <option value="生徒" {{ 'selected' if participant.role == '生徒' }}>生徒</option>
+            <option value="教師" {{ 'selected' if participant.role == '教師' }}>教師</option>
+            <option value="学年主任" {{ 'selected' if participant.role == '学年主任' }}>学年主任</option>
+            <option value="幹事" {{ 'selected' if participant.role == '幹事' }}>幹事</option>
+          </select>
+          <button type="submit" class="btn btn-primary btn-sm">変更</button>
+        </form>
+      </div>
+    </div>
+  </div>
+
   <!-- 幹事メモ -->
-  <div class="col-12">
-    <div class="card">
+  <div class="col-md-6">
+    <div class="card h-100">
       <div class="card-header fw-bold bg-light">幹事メモ</div>
       <div class="card-body">
         <form method="POST" action="{{ url_for('admin.update_memo', participant_id=participant.id) }}">

--- a/reunion/templates/admin/participants.html
+++ b/reunion/templates/admin/participants.html
@@ -122,6 +122,8 @@
                      href="{{ url_for('admin.participants', q=q, sort=sort, order=order, status=status_filter, final_status=final_filter, role='教師', class_name=class_filter) }}">教師</a></li>
               <li><a class="dropdown-item {{ 'active' if role_filter == '学年主任' }}"
                      href="{{ url_for('admin.participants', q=q, sort=sort, order=order, status=status_filter, final_status=final_filter, role='学年主任', class_name=class_filter) }}">学年主任</a></li>
+              <li><a class="dropdown-item {{ 'active' if role_filter == '幹事' }}"
+                     href="{{ url_for('admin.participants', q=q, sort=sort, order=order, status=status_filter, final_status=final_filter, role='幹事', class_name=class_filter) }}">幹事</a></li>
             </ul>
           </div>
           <a href="{{ sort_url('role') }}"><i class="bi {{ sort_icon('role') }}"></i></a>
@@ -194,15 +196,13 @@
         <td class="text-muted small">{{ p.id }}</td>
         <td>
           {{ p.display_name }}
-          {% if p.new_name %}
-            <br><span class="text-muted small">（旧: {{ p.name }}）</span>
-          {% endif %}
         </td>
         <td class="small text-center">{{ p.class_name or '' }}</td>
         <td class="small text-center">{{ p.student_number or '' }}</td>
         <td class="small">
           {% if p.role == '教師' %}<span class="badge bg-warning text-dark">教師</span>
           {% elif p.role == '学年主任' %}<span class="badge bg-danger">学年主任</span>
+          {% elif p.role == '幹事' %}<span class="badge bg-info text-dark">幹事</span>
           {% else %}<span class="badge bg-primary">生徒</span>{% endif %}
         </td>
         <td class="small">

--- a/reunion/templates/admin/roster.html
+++ b/reunion/templates/admin/roster.html
@@ -70,6 +70,7 @@
               <option value="生徒">生徒</option>
               <option value="教師">教師（担任・副担任）</option>
               <option value="学年主任">学年主任</option>
+              <option value="幹事">幹事</option>
             </select>
           </div>
           <div class="row g-2 mb-2">
@@ -98,49 +99,100 @@
 
 <!-- 名簿一覧 -->
 <div class="d-flex justify-content-between align-items-center mb-2">
-  <h5 class="mb-0">現在の名簿（{{ participants | length }} 名）</h5>
+  <h5 class="mb-0">現在の名簿（<span id="visibleCount">{{ participants | length }}</span> / {{ participants | length }} 名）</h5>
+  <button class="btn btn-outline-secondary btn-sm" id="clearFilters">
+    <i class="bi bi-x-circle me-1"></i>フィルター・並び順をリセット
+  </button>
 </div>
 
 <div class="table-responsive">
-  <table class="table table-hover table-sm align-middle">
+  <table class="table table-hover table-sm align-middle" id="rosterTable">
     <thead class="table-light">
-      <tr>
-        <th>ID</th>
-        <th>氏名</th>
-        <th>氏名（カナ）</th>
-        <th>メールアドレス</th>
-        <th>役割</th>
-        <th>クラス</th>
-        <th>出席番号</th>
-        <th>幹事メモ</th>
-        <th>仮出欠</th>
-        <th>本出欠</th>
-        <th>登録日</th>
+      <tr id="headerRow">
+        <th class="sortable" data-col="id" style="cursor:pointer;white-space:nowrap;">ID <span class="sort-icon text-muted">↕</span></th>
+        <th class="sortable" data-col="name" style="cursor:pointer;white-space:nowrap;">氏名 <span class="sort-icon text-muted">↕</span></th>
+        <th class="sortable" data-col="name_kana" style="cursor:pointer;white-space:nowrap;">氏名（カナ）<span class="sort-icon text-muted">↕</span></th>
+        <th class="sortable" data-col="email" style="cursor:pointer;white-space:nowrap;">メールアドレス <span class="sort-icon text-muted">↕</span></th>
+        <th class="sortable" data-col="role" style="cursor:pointer;white-space:nowrap;">役割 <span class="sort-icon text-muted">↕</span></th>
+        <th class="sortable" data-col="class" style="cursor:pointer;white-space:nowrap;">クラス <span class="sort-icon text-muted">↕</span></th>
+        <th class="sortable" data-col="number" style="cursor:pointer;white-space:nowrap;">出席番号 <span class="sort-icon text-muted">↕</span></th>
+        <th class="sortable" data-col="memo" style="cursor:pointer;white-space:nowrap;">幹事メモ <span class="sort-icon text-muted">↕</span></th>
+        <th class="sortable" data-col="prov" style="cursor:pointer;white-space:nowrap;">仮出欠 <span class="sort-icon text-muted">↕</span></th>
+        <th class="sortable" data-col="final" style="cursor:pointer;white-space:nowrap;">本出欠 <span class="sort-icon text-muted">↕</span></th>
+        <th class="sortable" data-col="created" style="cursor:pointer;white-space:nowrap;">登録日 <span class="sort-icon text-muted">↕</span></th>
         <th>操作</th>
       </tr>
+      <tr id="filterRow" class="table-secondary">
+        <td><input type="text" class="form-control form-control-sm" id="f-id" placeholder="検索"></td>
+        <td><input type="text" class="form-control form-control-sm" id="f-name" placeholder="検索"></td>
+        <td><input type="text" class="form-control form-control-sm" id="f-name-kana" placeholder="検索"></td>
+        <td><input type="text" class="form-control form-control-sm" id="f-email" placeholder="検索"></td>
+        <td>
+          <select class="form-select form-select-sm" id="f-role">
+            <option value="">全て</option>
+            <option value="生徒">生徒</option>
+            <option value="教師">教師</option>
+            <option value="学年主任">学年主任</option>
+            <option value="幹事">幹事</option>
+          </select>
+        </td>
+        <td><input type="text" class="form-control form-control-sm" id="f-class" placeholder="検索"></td>
+        <td><input type="text" class="form-control form-control-sm" id="f-number" placeholder="検索"></td>
+        <td><input type="text" class="form-control form-control-sm" id="f-memo" placeholder="検索"></td>
+        <td>
+          <select class="form-select form-select-sm" id="f-prov">
+            <option value="">全て</option>
+            <option value="参加">参加</option>
+            <option value="不参加">不参加</option>
+            <option value="未定">未定</option>
+            <option value="未回答">未回答</option>
+          </select>
+        </td>
+        <td>
+          <select class="form-select form-select-sm" id="f-final">
+            <option value="">全て</option>
+            <option value="参加">参加</option>
+            <option value="不参加">不参加</option>
+            <option value="未回答">未回答</option>
+          </select>
+        </td>
+        <td><input type="text" class="form-control form-control-sm" id="f-created" placeholder="例: 2024/05"></td>
+        <td></td>
+      </tr>
     </thead>
-    <tbody>
+    <tbody id="rosterTbody">
       {% for p in participants %}
       {% set prov = p.latest_provisional %}
       {% set final = p.latest_final %}
+      {% if prov %}
+        {% if prov.status == 'attending' %}{% set prov_label = '参加' %}
+        {% elif prov.status == 'not_attending' %}{% set prov_label = '不参加' %}
+        {% else %}{% set prov_label = '未定' %}{% endif %}
+      {% else %}{% set prov_label = '未回答' %}{% endif %}
+      {% if final %}
+        {% if final.status == 'attending' %}{% set final_label = '参加' %}
+        {% else %}{% set final_label = '不参加' %}{% endif %}
+      {% else %}{% set final_label = '未回答' %}{% endif %}
+      {% set role_sort = {'生徒': 0, '教師': 1, '学年主任': 2, '幹事': 3}.get(p.role, 9) %}
       <tr>
-        <td class="text-muted small">{{ p.id }}</td>
-        <td>
+        <td data-col="id" data-val="{{ p.id }}" data-sort="{{ p.id }}" class="text-muted small">{{ p.id }}</td>
+        <td data-col="name" data-val="{{ p.name }}">
           <a href="{{ url_for('admin.participant_detail', participant_id=p.id) }}">{{ p.name }}</a>
         </td>
-        <td class="small text-muted">{{ p.name_kana or '' }}</td>
-        <td class="small">
+        <td data-col="name_kana" data-val="{{ p.name_kana or '' }}" class="small text-muted">{{ p.name_kana or '' }}</td>
+        <td data-col="email" data-val="{{ p.email if p.email and '@placeholder.local' not in p.email else '' }}" class="small">
           {% if p.email and '@placeholder.local' not in p.email %}{{ p.email }}{% else %}<span class="text-muted">未登録</span>{% endif %}
         </td>
-        <td>
+        <td data-col="role" data-val="{{ p.role }}" data-sort="{{ role_sort }}">
           {% if p.role == '教師' %}<span class="badge bg-warning text-dark">教師</span>
           {% elif p.role == '学年主任' %}<span class="badge bg-danger">学年主任</span>
+          {% elif p.role == '幹事' %}<span class="badge bg-info text-dark">幹事</span>
           {% else %}<span class="badge bg-primary">生徒</span>{% endif %}
         </td>
-        <td class="small text-center">{{ p.class_name or '' }}</td>
-        <td class="small text-center">{{ p.student_number or '' }}</td>
-        <td class="small text-muted">{{ p.teacher_memo or '' }}</td>
-        <td>
+        <td data-col="class" data-val="{{ p.class_name or '' }}" class="small text-center">{{ p.class_name or '' }}</td>
+        <td data-col="number" data-val="{{ p.student_number or '' }}" data-sort="{{ p.student_number if p.student_number and p.student_number.isdigit() else '9999' }}" class="small text-center">{{ p.student_number or '' }}</td>
+        <td data-col="memo" data-val="{{ p.teacher_memo or '' }}" class="small text-muted">{{ p.teacher_memo or '' }}</td>
+        <td data-col="prov" data-val="{{ prov_label }}">
           {% if prov %}
             {% if prov.status == 'attending' %}<span class="badge bg-success">参加</span>
             {% elif prov.status == 'not_attending' %}<span class="badge bg-secondary">不参加</span>
@@ -149,7 +201,7 @@
             <span class="badge bg-light text-muted border">未回答</span>
           {% endif %}
         </td>
-        <td>
+        <td data-col="final" data-val="{{ final_label }}">
           {% if final %}
             {% if final.status == 'attending' %}<span class="badge bg-success">参加</span>
             {% else %}<span class="badge bg-secondary">不参加</span>{% endif %}
@@ -157,7 +209,7 @@
             <span class="badge bg-light text-muted border">未回答</span>
           {% endif %}
         </td>
-        <td class="small text-muted">{{ p.created_at | jst('%Y/%m/%d') }}</td>
+        <td data-col="created" data-val="{{ p.created_at | jst('%Y/%m/%d') }}" class="small text-muted">{{ p.created_at | jst('%Y/%m/%d') }}</td>
         <td>
           <form method="POST"
                 action="{{ url_for('admin.roster_delete', participant_id=p.id) }}"
@@ -167,13 +219,12 @@
         </td>
       </tr>
       {% else %}
-      <tr>
-        <td colspan="8" class="text-center text-muted py-5">
+      <tr id="emptyRow">
+        <td colspan="12" class="text-center text-muted py-5">
           名簿がありません。CSVを取込むか、1名ずつ追加してください。
         </td>
       </tr>
       {% endfor %}
-
     </tbody>
   </table>
 </div>
@@ -181,6 +232,7 @@
 
 {% block extra_js %}
 <script>
+(function () {
   var classInput = document.getElementById('classNameInput');
   var kanaInput  = document.getElementById('nameKanaInput');
   var kanaReq    = document.getElementById('kanaRequired');
@@ -192,8 +244,145 @@
     kanaReq.classList.toggle('d-none', !needKana);
     kanaHint.classList.toggle('d-none', !needKana);
   }
+  if (classInput) {
+    classInput.addEventListener('input', updateKanaRequired);
+    updateKanaRequired();
+  }
 
-  classInput.addEventListener('input', updateKanaRequired);
-  updateKanaRequired();
+  // ---- フィルター & ソート ----
+  var tbody = document.getElementById('rosterTbody');
+  if (!tbody) return;
+
+  var COLS = [
+    { col: 'id',        filterId: 'f-id',        isSelect: false },
+    { col: 'name',      filterId: 'f-name',      isSelect: false },
+    { col: 'name_kana', filterId: 'f-name-kana', isSelect: false },
+    { col: 'email',     filterId: 'f-email',     isSelect: false },
+    { col: 'role',      filterId: 'f-role',      isSelect: true  },
+    { col: 'class',     filterId: 'f-class',     isSelect: false },
+    { col: 'number',    filterId: 'f-number',    isSelect: false },
+    { col: 'memo',      filterId: 'f-memo',      isSelect: false },
+    { col: 'prov',      filterId: 'f-prov',      isSelect: true  },
+    { col: 'final',     filterId: 'f-final',     isSelect: true  },
+    { col: 'created',   filterId: 'f-created',   isSelect: false },
+  ];
+
+  var sortCol = null;
+  var sortAsc = true;
+
+  function getVal(row, col) {
+    var td = row.querySelector('td[data-col="' + col + '"]');
+    return td ? (td.dataset.val || '') : '';
+  }
+
+  function getSortVal(row, col) {
+    var td = row.querySelector('td[data-col="' + col + '"]');
+    if (!td) return '';
+    return td.dataset.sort !== undefined ? td.dataset.sort : (td.dataset.val || '');
+  }
+
+  function applyAll() {
+    // 全データ行（emptyRow以外）
+    var allRows = Array.from(tbody.querySelectorAll('tr')).filter(function(r) {
+      return r.id !== 'emptyRow';
+    });
+
+    // ソート
+    if (sortCol) {
+      allRows.sort(function(a, b) {
+        var va = getSortVal(a, sortCol);
+        var vb = getSortVal(b, sortCol);
+        var na = parseFloat(va);
+        var nb = parseFloat(vb);
+        var cmp;
+        if (!isNaN(na) && !isNaN(nb)) {
+          cmp = na - nb;
+        } else {
+          cmp = va.localeCompare(vb, 'ja');
+        }
+        return sortAsc ? cmp : -cmp;
+      });
+      allRows.forEach(function(row) { tbody.appendChild(row); });
+    }
+
+    // フィルター
+    var filterVals = {};
+    COLS.forEach(function(c) {
+      var el = document.getElementById(c.filterId);
+      filterVals[c.col] = el ? el.value.trim() : '';
+    });
+
+    var count = 0;
+    allRows.forEach(function(row) {
+      var show = true;
+      COLS.forEach(function(c) {
+        var fval = filterVals[c.col];
+        if (!fval) return;
+        var val = getVal(row, c.col);
+        if (c.isSelect) {
+          if (val !== fval) show = false;
+        } else {
+          if (val.toLowerCase().indexOf(fval.toLowerCase()) === -1) show = false;
+        }
+      });
+      row.style.display = show ? '' : 'none';
+      if (show) count++;
+    });
+
+    var countEl = document.getElementById('visibleCount');
+    if (countEl) countEl.textContent = count;
+  }
+
+  // フィルター入力にリスナーを設定
+  COLS.forEach(function(c) {
+    var el = document.getElementById(c.filterId);
+    if (el) el.addEventListener('input', applyAll);
+  });
+
+  // ヘッダークリックでソート
+  document.querySelectorAll('th.sortable').forEach(function(th) {
+    th.addEventListener('click', function() {
+      var col = th.dataset.col;
+      if (sortCol === col) {
+        sortAsc = !sortAsc;
+      } else {
+        sortCol = col;
+        sortAsc = true;
+      }
+      document.querySelectorAll('th.sortable').forEach(function(t) {
+        var icon = t.querySelector('.sort-icon');
+        if (!icon) return;
+        if (t.dataset.col === sortCol) {
+          icon.textContent = sortAsc ? '↑' : '↓';
+          icon.classList.remove('text-muted');
+        } else {
+          icon.textContent = '↕';
+          icon.classList.add('text-muted');
+        }
+      });
+      applyAll();
+    });
+  });
+
+  // リセットボタン
+  var clearBtn = document.getElementById('clearFilters');
+  if (clearBtn) {
+    clearBtn.addEventListener('click', function() {
+      COLS.forEach(function(c) {
+        var el = document.getElementById(c.filterId);
+        if (el) el.value = '';
+      });
+      sortCol = null;
+      sortAsc = true;
+      document.querySelectorAll('th.sortable .sort-icon').forEach(function(icon) {
+        icon.textContent = '↕';
+        icon.classList.add('text-muted');
+      });
+      applyAll();
+    });
+  }
+
+  applyAll();
+})();
 </script>
 {% endblock %}


### PR DESCRIPTION
- models.py: new_name / new_name_kana カラムを削除
- admin.py: 検索・CSV取込・CSV出力から新氏名関連を完全削除
- admin.py: 役割に「幹事」を追加（VALID_ROLES・ソート順）
- admin.py: 参加者役割更新ルート（update-role）を新設
- admin.py: CSVエクスポートに「備考」「支払予定金額」を追加、インポートも対応
- roster.html: 全列にフィルター行・昇降順ソートを追加（クライアントサイドJS）
- participant_detail.html: 役割変更フォームを追加
- participants.html: 役割フィルターに幹事を追加