### PR TITLE
参加者: クリア・一括送信リンク化・名前保護・上書きブロック・入金CSVエクスポート

### DIFF
--- a/reunion/routes/admin.py
+++ b/reunion/routes/admin.py
@@ -375,6 +375,24 @@ def update_memo(participant_id):
     return redirect(url_for("admin.participant_detail", participant_id=participant_id))
 
 
+@admin_bp.route("/participant/<int:participant_id>/clear-responses", methods=["POST"])
+def clear_responses(participant_id):
+    """参加者の回答・入金データを全てクリアして未回答状態に戻す"""
+    from models import ProvisionalResponse, FinalResponse, Payment
+    participant = db.session.get(Participant, participant_id)
+    if participant is None:
+        flash("参加者が見つかりません。", "danger")
+        return redirect(url_for("admin.participants"))
+
+    ProvisionalResponse.query.filter_by(participant_id=participant_id).delete()
+    FinalResponse.query.filter_by(participant_id=participant_id).delete()
+    Payment.query.filter_by(participant_id=participant_id).delete()
+    participant.updated_at = datetime.utcnow()
+    db.session.commit()
+    flash(f"{participant.name} の回答・入金データをクリアしました。", "success")
+    return redirect(url_for("admin.participant_detail", participant_id=participant_id))
+
+
 @admin_bp.route("/participant/<int:participant_id>/update-role", methods=["POST"])
 def update_role(participant_id):
     """役割を更新"""
@@ -1172,6 +1190,52 @@ def payments():
                            total_expected=total_expected,
                            total_paid=total_paid,
                            bank_imports=bank_imports)
+
+
+@admin_bp.route("/payments/export")
+def payments_export():
+    """入金一覧をCSVエクスポート"""
+    from models import Payment
+    payments = (
+        Payment.query
+        .join(Participant, Payment.participant_id == Participant.id)
+        .order_by(Participant.class_name, Participant.student_number)
+        .all()
+    )
+
+    PAY_LABELS = {"unpaid": "未払い", "paid": "支払済み", "partial": "一部支払い"}
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow([
+        "氏名", "氏名（カナ）", "クラス", "出席番号", "役割",
+        "入金ステータス", "入金金額", "支払予定金額", "支払日", "振込名義",
+        "CSV照合", "CSV上の名義", "CSV上の金額", "CSV上の日付",
+    ])
+    for pay in payments:
+        p = pay.participant
+        writer.writerow([
+            p.name,
+            p.name_kana or "",
+            p.class_name or "",
+            p.student_number or "",
+            p.role or "生徒",
+            PAY_LABELS.get(pay.payment_status, pay.payment_status),
+            pay.paid_amount or 0,
+            pay.expected_amount or 0,
+            pay.payment_date.strftime("%Y-%m-%d") if pay.payment_date else "",
+            pay.transfer_name or "",
+            "照合済み" if pay.bank_csv_matched else "未照合",
+            pay.bank_csv_raw_name or "",
+            pay.bank_csv_amount or "",
+            pay.bank_csv_date.strftime("%Y-%m-%d") if pay.bank_csv_date else "",
+        ])
+
+    return Response(
+        "﻿" + output.getvalue(),
+        mimetype="text/csv",
+        headers={"Content-Disposition": "attachment; filename=payments_export.csv"}
+    )
 
 
 @admin_bp.route("/payment/<int:payment_id>/update", methods=["POST"])

--- a/reunion/routes/forms.py
+++ b/reunion/routes/forms.py
@@ -136,6 +136,21 @@ def provisional():
     if participant_id:
         participant = db.session.get(Participant, int(participant_id))
         if participant:
+            stored_email_real = participant.email and PLACEHOLDER_DOMAIN not in participant.email
+            already_responded = bool(participant.provisional_responses)
+
+            # 回答済み＆別メールアドレス → 別人による上書き試みをブロック
+            if already_responded and stored_email_real and participant.email != email:
+                flash(
+                    f"「{participant.name}」さんはすでに別のメールアドレスで回答済みです。"
+                    " ご本人のメールアドレスで再度ご回答いただくか、幹事にお問い合わせください。",
+                    "danger"
+                )
+                return render_template("provisional_form.html",
+                                       name=name, name_kana=name_kana,
+                                       email=email, status=status,
+                                       class_name=class_name)
+
             # 同じメールを持つ別の参加者が既にいるか確認
             existing_by_email = Participant.query.filter_by(email=email).first()
             if existing_by_email and existing_by_email.id != participant.id:
@@ -145,9 +160,10 @@ def provisional():
                                        email=email, status=status,
                                        class_name=class_name)
             participant.email = email
-            if name:
+            # 既に名前が登録されている場合は上書きしない
+            if name and not participant.name:
                 participant.name = name
-            if name_kana:
+            if name_kana and not participant.name_kana:
                 participant.name_kana = name_kana
             participant.updated_at = datetime.utcnow()
             matched_how = "selected"
@@ -161,12 +177,11 @@ def provisional():
         participant = Participant.query.filter_by(email=email).first()
 
         if participant and PLACEHOLDER_DOMAIN not in participant.email:
-            participant.name = name
-            if name_kana:
-                participant.name_kana = name_kana
+            # 名前は上書きせず登録済みの情報を保持する
             participant.updated_at = datetime.utcnow()
             matched_how = "email"
-            logger.info(f"既存参加者（メール一致）: {name} ({email})")
+            name = participant.name
+            logger.info(f"既存参加者（メール一致）: {participant.name} ({email})")
 
         elif not participant:
             # ── ステップ3: 氏名で名簿を検索（名寄せ）──

--- a/reunion/templates/admin/participant_detail.html
+++ b/reunion/templates/admin/participant_detail.html
@@ -272,6 +272,23 @@
   </div>
   {% endif %}
 
+  <!-- 回答クリア -->
+  <div class="col-12">
+    <div class="card border-danger">
+      <div class="card-header fw-bold text-danger bg-light">危険な操作</div>
+      <div class="card-body">
+        <p class="text-muted small mb-2">仮出欠・本出欠・入金データを全て削除し、未回答状態に戻します。</p>
+        <form method="POST"
+              action="{{ url_for('admin.clear_responses', participant_id=participant.id) }}"
+              onsubmit="return confirm('{{ participant.name }} の回答・入金データを全てクリアします。この操作は取り消せません。よろしいですか？')">
+          <button type="submit" class="btn btn-outline-danger btn-sm">
+            <i class="bi bi-trash me-1"></i>回答・入金データをクリア
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+
 </div>
 
 <!-- メールプレビューモーダル -->

--- a/reunion/templates/admin/participants.html
+++ b/reunion/templates/admin/participants.html
@@ -47,24 +47,15 @@
     <a href="{{ url_for('admin.roster_export') }}" class="btn btn-outline-secondary btn-sm">
       <i class="bi bi-download me-1"></i>CSVエクスポート
     </a>
-    <form method="POST" action="{{ url_for('admin.send_final_url_bulk') }}"
-          onsubmit="return confirm('本出欠URL未送信の全員に一括送信します。よろしいですか？')">
-      <button type="submit" class="btn btn-success btn-sm">
-        <i class="bi bi-envelope-fill me-1"></i>本出欠URL一括送信
-      </button>
-    </form>
-    <form method="POST" action="{{ url_for('admin.send_reminder_bulk') }}"
-          onsubmit="return confirm('本出欠URL送信済み＆未回答の方にリマインドを一括送信します。よろしいですか？')">
-      <button type="submit" class="btn btn-primary btn-sm">
-        <i class="bi bi-bell-fill me-1"></i>本出欠リマインド一括送信
-      </button>
-    </form>
-    <form method="POST" action="{{ url_for('admin.send_final_reminder_bulk') }}"
-          onsubmit="return confirm('本出欠参加者に最終リマインドメール（PDF添付）を送信します。よろしいですか？')">
-      <button type="submit" class="btn btn-danger btn-sm">
-        <i class="bi bi-file-earmark-pdf me-1"></i>最終リマインド一括送信
-      </button>
-    </form>
+    <a href="{{ url_for('admin.mail_hub') }}" class="btn btn-success btn-sm">
+      <i class="bi bi-envelope-fill me-1"></i>本出欠URL一括送信
+    </a>
+    <a href="{{ url_for('admin.mail_hub') }}" class="btn btn-primary btn-sm">
+      <i class="bi bi-bell-fill me-1"></i>本出欠リマインド一括送信
+    </a>
+    <a href="{{ url_for('admin.mail_hub') }}" class="btn btn-danger btn-sm">
+      <i class="bi bi-file-earmark-pdf me-1"></i>最終リマインド一括送信
+    </a>
   </div>
 </div>
 

--- a/reunion/templates/admin/payments.html
+++ b/reunion/templates/admin/payments.html
@@ -25,6 +25,12 @@
   <!-- ========== 入金一覧タブ ========== -->
   <div class="tab-pane fade show active" id="listPane" role="tabpanel">
 
+    <div class="d-flex justify-content-end mb-2">
+      <a href="{{ url_for('admin.payments_export') }}" class="btn btn-outline-secondary btn-sm">
+        <i class="bi bi-download me-1"></i>入金一覧CSVエクスポート
+      </a>
+    </div>
+
     <!-- 集計 -->
     <div class="row g-2 mb-3">
       <div class="col-6 col-md-3">


### PR DESCRIPTION
- 個人ページに「回答・入金データをクリア」ボタンを追加（admin.clear_responses）
- 参加者一覧の一括送信ボタンをメール送信ページへのリンクに変更
- 仮出欠フォーム再送信時に登録済みの氏名を上書きしないよう修正
- ドロップダウン選択後、回答済み参加者への別メールアドレスによる上書きをブロック
- 入金一覧CSVエクスポート機能を追加（照合情報含む）