### PR TITLE
参加者一覧: 一括送信ボタンをメール種別プレビュー直リンクに変更

### DIFF
--- a/reunion/templates/admin/participants.html
+++ b/reunion/templates/admin/participants.html
@@ -47,13 +47,13 @@
     <a href="{{ url_for('admin.roster_export') }}" class="btn btn-outline-secondary btn-sm">
       <i class="bi bi-download me-1"></i>CSVエクスポート
     </a>
-    <a href="{{ url_for('admin.mail_hub') }}" class="btn btn-success btn-sm">
+    <a href="{{ url_for('admin.mail_hub') }}?type=final_url" class="btn btn-success btn-sm">
       <i class="bi bi-envelope-fill me-1"></i>本出欠URL一括送信
     </a>
-    <a href="{{ url_for('admin.mail_hub') }}" class="btn btn-primary btn-sm">
+    <a href="{{ url_for('admin.mail_hub') }}?type=reminder" class="btn btn-primary btn-sm">
       <i class="bi bi-bell-fill me-1"></i>本出欠リマインド一括送信
     </a>
-    <a href="{{ url_for('admin.mail_hub') }}" class="btn btn-danger btn-sm">
+    <a href="{{ url_for('admin.mail_hub') }}?type=final_reminder" class="btn btn-danger btn-sm">
       <i class="bi bi-file-earmark-pdf me-1"></i>最終リマインド一括送信
     </a>
   </div>


### PR DESCRIPTION
?type= パラメータで mail_hub のプレビューを自動選択・表示する既存の仕組みを活用。