### PR TITLE
statusページのデザイン刷新

### DIFF
--- a/reunion/app.py
+++ b/reunion/app.py
@@ -113,52 +113,48 @@ def create_app():
     def status():
         from flask import render_template
         from models import Participant
-        participants = Participant.query.all()
 
-        prov_attending, prov_not_attending, prov_undecided, prov_no_response = [], [], [], []
-        final_attending, final_not_attending, final_no_response = [], [], []
+        def _class_label(cls):
+            if cls and len(cls) >= 2 and cls.isdigit():
+                return f"{cls[0]}年{cls[1]}組"
+            return cls or "不明"
+
+        TEACHER_ROLES = {"教師", "学年主任", "副担任"}
+
+        participants = Participant.query.all()
+        prov_stats  = {"attending": 0, "not_attending": 0, "undecided": 0, "no_response": 0}
+        final_stats = {"attending": 0, "not_attending": 0, "no_response": 0}
+        student_map = {}
+        teachers    = []
 
         for p in participants:
-            prov = p.latest_provisional
+            prov  = p.latest_provisional
             final = p.latest_final
-            if prov:
-                if prov.status == "attending":
-                    prov_attending.append(p.name)
-                elif prov.status == "not_attending":
-                    prov_not_attending.append(p.name)
-                else:
-                    prov_undecided.append(p.name)
-            else:
-                prov_no_response.append(p.name)
+            ps = prov.status  if prov  else "no_response"
+            fs = (final.status if final.status != "cancelled" else "not_attending") if final else "no_response"
 
-            if final:
-                if final.status == "attending":
-                    final_attending.append(p.name)
-                else:
-                    final_not_attending.append(p.name)
-            else:
-                final_no_response.append(p.name)
+            prov_stats[ps]  = prov_stats.get(ps, 0)  + 1
+            final_stats[fs] = final_stats.get(fs, 0) + 1
 
-        stats = {
-            "total": len(participants),
-            "prov_attending": len(prov_attending),
-            "prov_not_attending": len(prov_not_attending),
-            "prov_undecided": len(prov_undecided),
-            "prov_no_response": len(prov_no_response),
-            "final_attending": len(final_attending),
-            "final_not_attending": len(final_not_attending),
-            "final_no_response": len(final_no_response),
-        }
-        breakdown = {
-            "prov_attending": prov_attending,
-            "prov_not_attending": prov_not_attending,
-            "prov_undecided": prov_undecided,
-            "prov_no_response": prov_no_response,
-            "final_attending": final_attending,
-            "final_not_attending": final_not_attending,
-            "final_no_response": final_no_response,
-        }
-        return render_template("status.html", stats=stats, breakdown=breakdown)
+            info = {"name": p.name, "prov": ps, "final": fs}
+            if p.role in TEACHER_ROLES:
+                teachers.append(info)
+            else:
+                cls = p.class_name or ""
+                student_map.setdefault(cls, []).append(info)
+
+        sorted_classes = [
+            {"key": cls, "label": _class_label(cls), "people": people}
+            for cls, people in sorted(student_map.items(), key=lambda x: (not x[0], x[0]))
+        ]
+
+        return render_template("status.html",
+            prov_stats=prov_stats,
+            final_stats=final_stats,
+            sorted_classes=sorted_classes,
+            teachers=teachers,
+            total=len(participants),
+        )
 
     # -----------------------------------------------
     # エラーハンドラ

--- a/reunion/templates/status.html
+++ b/reunion/templates/status.html
@@ -5,198 +5,194 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>参加状況</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
   <style>
-    body { background: #f8f9fa; }
-    .chart-wrap { position: relative; max-width: 200px; margin: 0 auto; }
-    .chart-center { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; pointer-events: none; }
-    .chart-center .num { font-size: 1.8rem; font-weight: 700; line-height: 1; }
-    .chart-center .label { font-size: 0.7rem; color: #6c757d; }
-    .chart-legend { list-style: none; padding: 0; margin: 0.75rem 0 0; }
-    .chart-legend li { display: flex; align-items: center; gap: 0.4rem; font-size: 0.85rem; padding: 4px 8px; border-radius: 6px; }
-    .chart-legend .dot { width: 12px; height: 12px; border-radius: 50%; flex-shrink: 0; }
-    .chart-legend .val { font-weight: 600; margin-left: auto; }
-    .name-badge { display: inline-block; background: #fff; border: 1px solid #dee2e6; border-radius: 20px; padding: 2px 12px; margin: 3px; font-size: 0.875rem; }
+    body { background: #f5f5f7; }
+    .chart-wrap { position: relative; max-width: 180px; margin: 0 auto; }
+    .chart-center {
+      position: absolute; top: 50%; left: 50%;
+      transform: translate(-50%, -50%);
+      text-align: center; pointer-events: none;
+    }
+    .chart-center .num  { font-size: 1.6rem; font-weight: 700; line-height: 1; }
+    .chart-center .lbl  { font-size: 0.65rem; color: #6c757d; }
+    .legend-list { list-style: none; padding: 0; margin: 0.6rem 0 0; display: flex; flex-wrap: wrap; justify-content: center; gap: 6px 14px; }
+    .legend-list li { display: flex; align-items: center; gap: 5px; font-size: 0.82rem; }
+    .legend-dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }
+    .legend-val { font-weight: 600; }
+    .acc-btn {
+      background: #fff; border: none; border-radius: 10px;
+      width: 100%; display: flex; align-items: center;
+      padding: 10px 14px; font-size: 0.9rem; font-weight: 600;
+      box-shadow: 0 1px 4px rgba(0,0,0,.08);
+      cursor: pointer; transition: background 0.15s;
+    }
+    .acc-btn:hover { background: #f0f0f0; }
+    .acc-btn .arrow { margin-left: auto; transition: transform 0.2s; font-size: 0.75rem; color: #aaa; }
+    .acc-btn.open .arrow { transform: rotate(90deg); }
+    .acc-body { display: none; background: #fff; border-radius: 0 0 10px 10px; padding: 4px 0 8px; margin-top: -4px; box-shadow: 0 2px 4px rgba(0,0,0,.06); }
+    .acc-body.show { display: block; }
+    .person-row { display: flex; align-items: center; padding: 6px 14px; border-bottom: 1px solid #f0f0f0; font-size: 0.875rem; }
+    .person-row:last-child { border-bottom: none; }
+    .section-label { font-size: 0.78rem; font-weight: 700; color: #6c757d; letter-spacing: .05em; margin: 16px 0 6px; }
   </style>
 </head>
 <body>
-<div class="container py-4" style="max-width: 720px;">
-  <h5 class="fw-bold mb-1"><i class="bi bi-people-fill me-2 text-primary"></i>参加状況</h5>
-  <p class="text-muted small mb-4">登録者数: {{ stats.total }}名</p>
+<div class="container py-4" style="max-width: 540px;">
 
-  <!-- 仮出欠 -->
+  <p class="fw-bold mb-3" style="font-size:1.05rem;">参加状況 <span class="text-muted fw-normal small">（{{ total }}名）</span></p>
+
+  <!-- Radio -->
+  <div class="btn-group w-100 mb-4" role="group">
+    <input type="radio" class="btn-check" name="ft" id="r-prov" value="prov" checked>
+    <label class="btn btn-outline-primary" for="r-prov">仮出欠</label>
+    <input type="radio" class="btn-check" name="ft" id="r-final" value="final">
+    <label class="btn btn-outline-primary" for="r-final">本出欠</label>
+  </div>
+
+  <!-- Chart -->
   <div class="card border-0 shadow-sm mb-4">
-    <div class="card-body">
-      <h6 class="text-muted mb-3">仮出欠</h6>
-      <div class="row align-items-start">
-        <div class="col-5">
-          <div class="chart-wrap">
-            <canvas id="chartProvisional"></canvas>
-            <div class="chart-center">
-              <div class="num">{{ stats.total }}</div>
-              <div class="label">登録者数</div>
-            </div>
-          </div>
-          <ul class="chart-legend" id="legendProvisional"></ul>
-        </div>
-        <div class="col-7">
-          <div class="mb-3">
-            <div class="small fw-bold text-success mb-1">仮参加（{{ stats.prov_attending }}名）</div>
-            <div>
-              {% for name in breakdown.prov_attending %}
-                <span class="name-badge">{{ name }}</span>
-              {% else %}
-                <span class="text-muted small">-</span>
-              {% endfor %}
-            </div>
-          </div>
-          <div class="mb-3">
-            <div class="small fw-bold text-secondary mb-1">仮不参加（{{ stats.prov_not_attending }}名）</div>
-            <div>
-              {% for name in breakdown.prov_not_attending %}
-                <span class="name-badge">{{ name }}</span>
-              {% else %}
-                <span class="text-muted small">-</span>
-              {% endfor %}
-            </div>
-          </div>
-          <div class="mb-3">
-            <div class="small fw-bold text-info mb-1">仮未定（{{ stats.prov_undecided }}名）</div>
-            <div>
-              {% for name in breakdown.prov_undecided %}
-                <span class="name-badge">{{ name }}</span>
-              {% else %}
-                <span class="text-muted small">-</span>
-              {% endfor %}
-            </div>
-          </div>
-          <div>
-            <div class="small fw-bold text-warning mb-1">未回答（{{ stats.prov_no_response }}名）</div>
-            <div>
-              {% for name in breakdown.prov_no_response %}
-                <span class="name-badge">{{ name }}</span>
-              {% else %}
-                <span class="text-muted small">-</span>
-              {% endfor %}
-            </div>
-          </div>
+    <div class="card-body py-3">
+      <div class="chart-wrap">
+        <canvas id="chart"></canvas>
+        <div class="chart-center">
+          <div class="num">{{ total }}</div>
+          <div class="lbl">登録者数</div>
         </div>
       </div>
+      <ul class="legend-list" id="legend"></ul>
     </div>
   </div>
 
-  <!-- 本出欠 -->
-  <div class="card border-0 shadow-sm mb-4">
-    <div class="card-body">
-      <h6 class="text-muted mb-3">本出欠</h6>
-      <div class="row align-items-start">
-        <div class="col-5">
-          <div class="chart-wrap">
-            <canvas id="chartFinal"></canvas>
-            <div class="chart-center">
-              <div class="num">{{ stats.total }}</div>
-              <div class="label">登録者数</div>
-            </div>
-          </div>
-          <ul class="chart-legend" id="legendFinal"></ul>
+  <!-- Students -->
+  {% if sorted_classes %}
+  <div class="section-label">生徒</div>
+  <div class="d-flex flex-column gap-2" id="acc-students">
+    {% for cls in sorted_classes %}
+    <div class="acc-item">
+      <button class="acc-btn" data-target="cls-{{ loop.index }}">
+        <span>{{ cls.label }}</span>
+        <span class="ms-2 text-muted fw-normal small cls-count" data-key="{{ cls.key }}">{{ cls.people|length }}名</span>
+        <span class="arrow">▶</span>
+      </button>
+      <div class="acc-body" id="cls-{{ loop.index }}">
+        {% for p in cls.people %}
+        <div class="person-row" data-prov="{{ p.prov }}" data-final="{{ p.final }}">
+          <span class="flex-grow-1">{{ p.name }}</span>
+          <span class="badge person-badge ms-2"></span>
         </div>
-        <div class="col-7">
-          <div class="mb-3">
-            <div class="small fw-bold text-success mb-1">本参加（{{ stats.final_attending }}名）</div>
-            <div>
-              {% for name in breakdown.final_attending %}
-                <span class="name-badge">{{ name }}</span>
-              {% else %}
-                <span class="text-muted small">-</span>
-              {% endfor %}
-            </div>
-          </div>
-          <div class="mb-3">
-            <div class="small fw-bold text-secondary mb-1">本不参加（{{ stats.final_not_attending }}名）</div>
-            <div>
-              {% for name in breakdown.final_not_attending %}
-                <span class="name-badge">{{ name }}</span>
-              {% else %}
-                <span class="text-muted small">-</span>
-              {% endfor %}
-            </div>
-          </div>
-          <div>
-            <div class="small fw-bold text-warning mb-1">未回答（{{ stats.final_no_response }}名）</div>
-            <div>
-              {% for name in breakdown.final_no_response %}
-                <span class="name-badge">{{ name }}</span>
-              {% else %}
-                <span class="text-muted small">-</span>
-              {% endfor %}
-            </div>
-          </div>
-        </div>
+        {% endfor %}
       </div>
     </div>
+    {% endfor %}
   </div>
+  {% endif %}
 
-  <p class="text-center text-muted small">このページは閲覧専用です。</p>
+  <!-- Teachers -->
+  {% if teachers %}
+  <div class="section-label">先生</div>
+  <div class="acc-item">
+    <button class="acc-btn" data-target="cls-teachers">
+      <span>先生・その他</span>
+      <span class="ms-2 text-muted fw-normal small">{{ teachers|length }}名</span>
+      <span class="arrow">▶</span>
+    </button>
+    <div class="acc-body" id="cls-teachers">
+      {% for p in teachers %}
+      <div class="person-row" data-prov="{{ p.prov }}" data-final="{{ p.final }}">
+        <span class="flex-grow-1">{{ p.name }}</span>
+        <span class="badge person-badge ms-2"></span>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+  {% endif %}
+
+  <p class="text-center text-muted mt-4" style="font-size:0.75rem;">このページは閲覧専用です</p>
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
 <script>
-(function() {
-  function createDoughnut(canvasId, legendId, segments) {
-    var canvas = document.getElementById(canvasId);
-    var chart = new Chart(canvas, {
-      type: 'doughnut',
-      data: {
-        labels: segments.map(function(s){ return s.label; }),
-        datasets: [{
-          data: segments.map(function(s){ return s.value; }),
-          backgroundColor: segments.map(function(s){ return s.color; }),
-          borderWidth: 2,
-          borderColor: '#fff',
-          hoverOffset: 4
-        }]
+(function () {
+  const PROV  = { attending: {{ prov_stats.attending }}, not_attending: {{ prov_stats.not_attending }}, undecided: {{ prov_stats.undecided }}, no_response: {{ prov_stats.no_response }} };
+  const FINAL = { attending: {{ final_stats.attending }}, not_attending: {{ final_stats.not_attending }}, no_response: {{ final_stats.no_response }} };
+
+  const CFG = {
+    prov: {
+      segs: [
+        { key: 'attending',     label: '仮参加',   color: '#198754' },
+        { key: 'not_attending', label: '仮不参加', color: '#adb5bd' },
+        { key: 'undecided',     label: '未定',     color: '#0dcaf0' },
+        { key: 'no_response',   label: '未回答',   color: '#ffc107' },
+      ],
+      badge: {
+        attending:     ['bg-success',           '仮参加'],
+        not_attending: ['bg-secondary',         '仮不参加'],
+        undecided:     ['bg-info text-dark',    '未定'],
+        no_response:   ['bg-warning text-dark', '未回答'],
       },
-      options: {
-        cutout: '65%',
-        responsive: true,
-        maintainAspectRatio: true,
-        plugins: {
-          legend: { display: false },
-          tooltip: {
-            callbacks: {
-              label: function(ctx) {
-                var total = ctx.dataset.data.reduce(function(a,b){ return a+b; }, 0);
-                var pct = total > 0 ? (ctx.raw / total * 100).toFixed(1) : 0;
-                return ctx.label + ': ' + ctx.raw + ' (' + pct + '%)';
-              }
-            }
-          }
-        }
-      }
+      data: PROV,
+    },
+    final: {
+      segs: [
+        { key: 'attending',     label: '本参加',   color: '#198754' },
+        { key: 'not_attending', label: '本不参加', color: '#adb5bd' },
+        { key: 'no_response',   label: '未回答',   color: '#ffc107' },
+      ],
+      badge: {
+        attending:     ['bg-success',           '本参加'],
+        not_attending: ['bg-secondary',         '本不参加'],
+        no_response:   ['bg-warning text-dark', '未回答'],
+      },
+      data: FINAL,
+    },
+  };
+
+  // Chart
+  const chart = new Chart(document.getElementById('chart'), {
+    type: 'doughnut',
+    data: { labels: [], datasets: [{ data: [], backgroundColor: [], borderWidth: 2, borderColor: '#fff', hoverOffset: 4 }] },
+    options: { cutout: '65%', responsive: true, maintainAspectRatio: true, plugins: { legend: { display: false } } },
+  });
+
+  function update(type) {
+    const cfg = CFG[type];
+    chart.data.labels                        = cfg.segs.map(s => s.label);
+    chart.data.datasets[0].data             = cfg.segs.map(s => cfg.data[s.key] || 0);
+    chart.data.datasets[0].backgroundColor  = cfg.segs.map(s => s.color);
+    chart.update();
+
+    const legend = document.getElementById('legend');
+    legend.innerHTML = '';
+    cfg.segs.forEach(s => {
+      const li = document.createElement('li');
+      li.innerHTML = `<span class="legend-dot" style="background:${s.color}"></span>${s.label}<span class="legend-val">${cfg.data[s.key] || 0}</span>`;
+      legend.appendChild(li);
     });
 
-    var legend = document.getElementById(legendId);
-    segments.forEach(function(s) {
-      var li = document.createElement('li');
-      li.innerHTML = '<span class="dot" style="background:' + s.color + '"></span>' +
-                     '<span>' + s.label + '</span>' +
-                     '<span class="val">' + s.value + '</span>';
-      legend.appendChild(li);
+    document.querySelectorAll('.person-row').forEach(row => {
+      const st  = row.dataset[type] || 'no_response';
+      const [cls, lbl] = cfg.badge[st] || cfg.badge['no_response'];
+      const badge = row.querySelector('.person-badge');
+      badge.className = 'badge person-badge ms-2 ' + cls;
+      badge.textContent = lbl;
     });
   }
 
-  createDoughnut('chartProvisional', 'legendProvisional', [
-    { label: '仮参加',   value: {{ stats.prov_attending }},     color: '#198754' },
-    { label: '仮不参加', value: {{ stats.prov_not_attending }}, color: '#adb5bd' },
-    { label: '仮未定',   value: {{ stats.prov_undecided }},     color: '#0dcaf0' },
-    { label: '未回答',   value: {{ stats.prov_no_response }},   color: '#ffc107' }
-  ]);
+  // Accordion
+  document.querySelectorAll('.acc-btn').forEach(btn => {
+    btn.addEventListener('click', function () {
+      const body = document.getElementById(this.dataset.target);
+      const open = body.classList.toggle('show');
+      this.classList.toggle('open', open);
+    });
+  });
 
-  createDoughnut('chartFinal', 'legendFinal', [
-    { label: '本参加',   value: {{ stats.final_attending }},     color: '#198754' },
-    { label: '本不参加', value: {{ stats.final_not_attending }}, color: '#adb5bd' },
-    { label: '未回答',   value: {{ stats.final_no_response }},   color: '#ffc107' }
-  ]);
+  // Radio
+  document.querySelectorAll('input[name="ft"]').forEach(r => {
+    r.addEventListener('change', function () { update(this.value); });
+  });
+
+  update('prov');
 })();
 </script>
 </body>


### PR DESCRIPTION
- 仮/本出欠をラジオボタンで切り替え（ページ遷移なし）
- 生徒・先生を分けて表示
- クラスごとのアコーディオンでタップ展開
- チャート→凡例→内訳の順でコンパクトに配置