### PR TITLE
名前共有の同意機能を追加

### DIFF
--- a/reunion/app.py
+++ b/reunion/app.py
@@ -21,6 +21,8 @@ def _migrate(db):
         ("final_responses", "bank_name",      "VARCHAR(100) DEFAULT ''"),
         ("final_responses", "branch_name",    "VARCHAR(100) DEFAULT ''"),
         ("final_responses", "account_number", "VARCHAR(50) DEFAULT ''"),
+        ("provisional_responses", "share_consent", "BOOLEAN DEFAULT 0"),
+        ("final_responses",       "share_consent", "BOOLEAN DEFAULT 0"),
     ]
     with db.engine.connect() as conn:
         for table, column, col_def in migrations:
@@ -132,11 +134,14 @@ def create_app():
             final = p.latest_final
             ps = prov.status  if prov  else "no_response"
             fs = (final.status if final.status != "cancelled" else "not_attending") if final else "no_response"
+            prov_consent  = bool(prov.share_consent)  if prov  else False
+            final_consent = bool(final.share_consent) if final else False
 
             prov_stats[ps]  = prov_stats.get(ps, 0)  + 1
             final_stats[fs] = final_stats.get(fs, 0) + 1
 
-            info = {"name": p.name, "prov": ps, "final": fs}
+            info = {"name": p.name, "prov": ps, "final": fs,
+                    "prov_consent": prov_consent, "final_consent": final_consent}
             if p.role in TEACHER_ROLES:
                 teachers.append(info)
             else:

--- a/reunion/models.py
+++ b/reunion/models.py
@@ -88,6 +88,7 @@ class ProvisionalResponse(db.Model):
     participant_id = db.Column(db.Integer, db.ForeignKey("participants.id"), nullable=False)
     # status: attending=参加 / not_attending=不参加 / undecided=未定
     status = db.Column(db.String(20), nullable=False, default="undecided")
+    share_consent = db.Column(db.Boolean, default=False)
     submitted_at = db.Column(db.DateTime, default=datetime.utcnow)
     ip_address = db.Column(db.String(50), default="")  # 送信元IPアドレス（簡易ログ用）
 
@@ -124,6 +125,7 @@ class FinalResponse(db.Model):
     payment_expected = db.Column(db.Integer, default=0)        # 支払予定金額（円）
     payment_method = db.Column(db.String(50), default="bank_transfer")  # 支払方法
     remarks = db.Column(db.Text, default="")                   # 備考
+    share_consent = db.Column(db.Boolean, default=False)
     submitted_at = db.Column(db.DateTime, default=datetime.utcnow)
     ip_address = db.Column(db.String(50), default="")
 

--- a/reunion/routes/admin.py
+++ b/reunion/routes/admin.py
@@ -360,6 +360,29 @@ def set_final_status(participant_id):
     return redirect(url_for("admin.participant_detail", participant_id=participant_id))
 
 
+@admin_bp.route("/participant/<int:participant_id>/toggle-consent/<response_type>", methods=["POST"])
+def toggle_consent(participant_id, response_type):
+    """仮/本出欠の名前共有同意を切り替え"""
+    participant = db.session.get(Participant, participant_id)
+    if participant is None:
+        flash("参加者が見つかりません。", "danger")
+        return redirect(url_for("admin.participants"))
+    if response_type == "provisional":
+        response = participant.latest_provisional
+    elif response_type == "final":
+        response = participant.latest_final
+    else:
+        response = None
+    if response is None:
+        flash("回答が見つかりません。", "danger")
+        return redirect(url_for("admin.participant_detail", participant_id=participant_id))
+    response.share_consent = not response.share_consent
+    db.session.commit()
+    label = "名前の共有を許可しました。" if response.share_consent else "共有許可を取り消しました。"
+    flash(label, "success")
+    return redirect(url_for("admin.participant_detail", participant_id=participant_id))
+
+
 @admin_bp.route("/participant/<int:participant_id>/memo", methods=["POST"])
 def update_memo(participant_id):
     """幹事メモを更新"""

--- a/reunion/routes/forms.py
+++ b/reunion/routes/forms.py
@@ -206,10 +206,13 @@ def provisional():
                 matched_how = "new"
                 logger.info(f"新規参加者登録: {name} ({email})")
 
+    share_consent = request.form.get("share_consent") == "1"
+
     # 仮出欠回答を追加
     response = ProvisionalResponse(
         participant_id=participant.id,
         status=status,
+        share_consent=share_consent,
         submitted_at=datetime.utcnow(),
         ip_address=request.remote_addr or "",
     )
@@ -387,6 +390,8 @@ def final(token):
     except ValueError:
         payment_expected = 0
 
+    share_consent = request.form.get("share_consent") == "1"
+
     response = FinalResponse(
         participant_id=participant.id,
         status=status,
@@ -395,6 +400,7 @@ def final(token):
         payment_expected=payment_expected,
         payment_method="bank_transfer",
         remarks=remarks,
+        share_consent=share_consent,
         submitted_at=datetime.utcnow(),
         ip_address=request.remote_addr or "",
     )

--- a/reunion/templates/admin/participant_detail.html
+++ b/reunion/templates/admin/participant_detail.html
@@ -65,6 +65,15 @@
           <button name="status" value="not_attending" class="btn btn-secondary btn-sm">不参加</button>
           <button name="status" value="undecided" class="btn btn-warning btn-sm">未定</button>
         </form>
+        {% if prov %}
+        <form method="POST" action="{{ url_for('admin.toggle_consent', participant_id=participant.id, response_type='provisional') }}" class="mt-2">
+          {% if prov.share_consent %}
+            <button class="btn btn-sm btn-outline-danger">共有許可を取り消す</button>
+          {% else %}
+            <button class="btn btn-sm btn-outline-primary">名前の共有を許可する</button>
+          {% endif %}
+        </form>
+        {% endif %}
       </div>
     </div>
   </div>
@@ -107,6 +116,15 @@
           <button name="status" value="attending" class="btn btn-success btn-sm">参加</button>
           <button name="status" value="not_attending" class="btn btn-secondary btn-sm">不参加</button>
         </form>
+        {% if final %}
+        <form method="POST" action="{{ url_for('admin.toggle_consent', participant_id=participant.id, response_type='final') }}" class="mt-2">
+          {% if final.share_consent %}
+            <button class="btn btn-sm btn-outline-danger">共有許可を取り消す</button>
+          {% else %}
+            <button class="btn btn-sm btn-outline-primary">名前の共有を許可する</button>
+          {% endif %}
+        </form>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/reunion/templates/final_form.html
+++ b/reunion/templates/final_form.html
@@ -524,6 +524,14 @@
                   >{{ existing.remarks if existing else '' }}</textarea>
                 </div>
 
+                <div class="mb-3 p-3 rounded" style="background:#f8f9fa; border:1px solid #dee2e6;">
+                  <div class="form-check">
+                    <input class="form-check-input" type="checkbox" name="share_consent" id="share_consent" value="1">
+                    <label class="form-check-label small" for="share_consent">
+                      回答内容を名前とともに参加者に共有することを許可する
+                    </label>
+                  </div>
+                </div>
                 <div class="d-grid">
                   <button
                     type="submit"

--- a/reunion/templates/provisional_form.html
+++ b/reunion/templates/provisional_form.html
@@ -121,6 +121,14 @@
                 </div>
               </div>
 
+              <div class="mb-3 p-3 rounded" style="background:#f8f9fa; border:1px solid #dee2e6;">
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" name="share_consent" id="share_consent" value="1">
+                  <label class="form-check-label small" for="share_consent">
+                    回答内容を名前とともに参加者に共有することを許可する
+                  </label>
+                </div>
+              </div>
               <div class="d-grid">
                 <button type="submit" class="btn btn-primary btn-lg" id="submitBtn" disabled>送信する</button>
               </div>

--- a/reunion/templates/status.html
+++ b/reunion/templates/status.html
@@ -143,11 +143,11 @@
 
   const CLASS_DATA = [
     {% for cls in sorted_classes %}
-    { label: "{{ cls.label }}", people: [{% for p in cls.people %}{ name: "{{ p.name }}", prov: "{{ p.prov }}", final: "{{ p.final }}" },{% endfor %}] },
+    { label: "{{ cls.label }}", people: [{% for p in cls.people %}{ name: "{{ p.name }}", prov: "{{ p.prov }}", final: "{{ p.final }}", prov_consent: {{ 'true' if p.prov_consent else 'false' }}, final_consent: {{ 'true' if p.final_consent else 'false' }} },{% endfor %}] },
     {% endfor %}
   ];
 
-  const TEACHER_DATA = [{% for p in teachers %}{ name: "{{ p.name }} 先生", prov: "{{ p.prov }}", final: "{{ p.final }}" },{% endfor %}];
+  const TEACHER_DATA = [{% for p in teachers %}{ name: "{{ p.name }} 先生", prov: "{{ p.prov }}", final: "{{ p.final }}", prov_consent: {{ 'true' if p.prov_consent else 'false' }}, final_consent: {{ 'true' if p.final_consent else 'false' }} },{% endfor %}];
 
   let currentType    = 'prov';
   let activeIdx      = null;
@@ -187,9 +187,34 @@
       legend.appendChild(li);
     });
 
-    document.querySelectorAll('.cls-body.show').forEach(b => applyBadges(type, b));
+    // 開いているクラスを再描画（名前表示がconsentで変わるため）
+    clsBtns.forEach((btn, idx) => {
+      const b = document.getElementById('cls-body-' + idx);
+      if (b && b.classList.contains('show')) {
+        const cls = CLASS_DATA[idx];
+        b.innerHTML = cls.people.map(p => {
+          const showName = type === 'prov' ? p.prov_consent : p.final_consent;
+          const displayName = showName ? p.name : '<span class="text-muted">非公開</span>';
+          return `<div class="person-row" data-prov="${p.prov}" data-final="${p.final}">
+            <span class="flex-grow-1">${displayName}</span>
+            <span class="badge person-badge ms-2"></span>
+          </div>`;
+        }).join('');
+        applyBadges(type, b);
+      }
+    });
     const teacherBody = document.getElementById('teacher-body');
-    if (teacherBody) applyBadges(type, teacherBody);
+    if (teacherBody && teacherBody.classList.contains('show')) {
+      teacherBody.innerHTML = TEACHER_DATA.map(p => {
+        const showName = type === 'prov' ? p.prov_consent : p.final_consent;
+        const displayName = showName ? p.name : '<span class="text-muted">非公開</span>';
+        return `<div class="person-row" data-prov="${p.prov}" data-final="${p.final}">
+          <span class="flex-grow-1">${displayName}</span>
+          <span class="badge person-badge ms-2"></span>
+        </div>`;
+      }).join('');
+      applyBadges(type, teacherBody);
+    }
   }
 
   // Class accordion (inline body per class)
@@ -212,12 +237,14 @@
       if (isOpen) return;
 
       const cls = CLASS_DATA[idx];
-      body.innerHTML = cls.people.map(p =>
-        `<div class="person-row" data-prov="${p.prov}" data-final="${p.final}">
-           <span class="flex-grow-1">${p.name}</span>
+      body.innerHTML = cls.people.map(p => {
+        const showName = currentType === 'prov' ? p.prov_consent : p.final_consent;
+        const displayName = showName ? p.name : '<span class="text-muted">非公開</span>';
+        return `<div class="person-row" data-prov="${p.prov}" data-final="${p.final}">
+           <span class="flex-grow-1">${displayName}</span>
            <span class="badge person-badge ms-2"></span>
-         </div>`
-      ).join('');
+         </div>`;
+      }).join('');
       applyBadges(currentType, body);
       body.classList.add('show');
       btn.classList.add('active');
@@ -232,12 +259,14 @@
     teacherBtn.addEventListener('click', function () {
       teacherOpen = !teacherOpen;
       if (teacherOpen) {
-        teacherBody.innerHTML = TEACHER_DATA.map(p =>
-          `<div class="person-row" data-prov="${p.prov}" data-final="${p.final}">
-             <span class="flex-grow-1">${p.name}</span>
+        teacherBody.innerHTML = TEACHER_DATA.map(p => {
+          const showName = currentType === 'prov' ? p.prov_consent : p.final_consent;
+          const displayName = showName ? p.name : '<span class="text-muted">非公開</span>';
+          return `<div class="person-row" data-prov="${p.prov}" data-final="${p.final}">
+             <span class="flex-grow-1">${displayName}</span>
              <span class="badge person-badge ms-2"></span>
-           </div>`
-        ).join('');
+           </div>`;
+        }).join('');
         applyBadges(currentType, teacherBody);
         teacherBody.classList.add('show');
         teacherBtn.classList.add('active');


### PR DESCRIPTION
- 仮・本出欠フォームに「名前とともに共有を許可する」チェックボックスを追加
- ProvisionalResponse/FinalResponseにshare_consentカラムを追加（マイグレーション対応）
- statusページ：合計人数は全員カウント、名前は同意者のみ表示・非同意者は「非公開」