### PR TITLE
出席状況の共有を幹事限定化（共有許可ボックス撤廃）

### DIFF
--- a/reunion/routes/forms.py
+++ b/reunion/routes/forms.py
@@ -206,13 +206,11 @@ def provisional():
                 matched_how = "new"
                 logger.info(f"新規参加者登録: {name} ({email})")
 
-    share_consent = request.form.get("share_consent") == "1"
-
     # 仮出欠回答を追加
     response = ProvisionalResponse(
         participant_id=participant.id,
         status=status,
-        share_consent=share_consent,
+        share_consent=True,
         submitted_at=datetime.utcnow(),
         ip_address=request.remote_addr or "",
     )
@@ -390,8 +388,6 @@ def final(token):
     except ValueError:
         payment_expected = 0
 
-    share_consent = request.form.get("share_consent") == "1"
-
     response = FinalResponse(
         participant_id=participant.id,
         status=status,
@@ -400,7 +396,7 @@ def final(token):
         payment_expected=payment_expected,
         payment_method="bank_transfer",
         remarks=remarks,
-        share_consent=share_consent,
+        share_consent=True,
         submitted_at=datetime.utcnow(),
         ip_address=request.remote_addr or "",
     )

--- a/reunion/templates/admin/participant_detail.html
+++ b/reunion/templates/admin/participant_detail.html
@@ -98,14 +98,6 @@
           <button name="status" value="not_attending" class="btn btn-secondary btn-sm">不参加</button>
           <button name="status" value="undecided" class="btn btn-warning btn-sm">未定</button>
         </form>
-        {% set consented = (prov and prov.share_consent) or (participant.latest_final and participant.latest_final.share_consent) %}
-        <form method="POST" action="{{ url_for('admin.toggle_consent', participant_id=participant.id, response_type='both') }}" class="mt-2">
-          {% if consented %}
-            <button class="btn btn-sm btn-outline-danger">名前共有を取り消す（仮・本）</button>
-          {% else %}
-            <button class="btn btn-sm btn-outline-primary">名前共有を許可する（仮・本）</button>
-          {% endif %}
-        </form>
       </div>
     </div>
   </div>

--- a/reunion/templates/final_form.html
+++ b/reunion/templates/final_form.html
@@ -524,19 +524,6 @@
                   >{{ existing.remarks if existing else '' }}</textarea>
                 </div>
 
-                <div class="mb-3 p-3 rounded" style="background:#f8f9fa; border:1px solid #dee2e6;">
-                  <p class="small mb-2 fw-bold">回答内容を名前とともに参加者に共有することを許可しますか？<span class="text-danger ms-1">*</span></p>
-                  <div class="d-flex gap-3">
-                    <div class="form-check">
-                      <input class="form-check-input" type="radio" name="share_consent" id="consent_yes" value="1" required>
-                      <label class="form-check-label" for="consent_yes">はい</label>
-                    </div>
-                    <div class="form-check">
-                      <input class="form-check-input" type="radio" name="share_consent" id="consent_no" value="0">
-                      <label class="form-check-label" for="consent_no">いいえ</label>
-                    </div>
-                  </div>
-                </div>
                 <div class="d-grid">
                   <button
                     type="submit"

--- a/reunion/templates/provisional_form.html
+++ b/reunion/templates/provisional_form.html
@@ -121,19 +121,6 @@
                 </div>
               </div>
 
-              <div class="mb-3 p-3 rounded" style="background:#f8f9fa; border:1px solid #dee2e6;">
-                <p class="small mb-2 fw-bold">回答内容を名前とともに参加者に共有することを許可しますか？<span class="text-danger ms-1">*</span></p>
-                <div class="d-flex gap-3">
-                  <div class="form-check">
-                    <input class="form-check-input" type="radio" name="share_consent" id="consent_yes" value="1" required>
-                    <label class="form-check-label" for="consent_yes">はい</label>
-                  </div>
-                  <div class="form-check">
-                    <input class="form-check-input" type="radio" name="share_consent" id="consent_no" value="0">
-                    <label class="form-check-label" for="consent_no">いいえ</label>
-                  </div>
-                </div>
-              </div>
               <div class="d-grid">
                 <button type="submit" class="btn btn-primary btn-lg" id="submitBtn" disabled>送信する</button>
               </div>
@@ -171,13 +158,9 @@ function checkReady() {
       if (formLocked) return;
       var hasName = participantId.value || nameText.value.trim();
       var hasEmail = emailInput.value.trim() && emailInput.value.includes('@');
-      var hasConsent = !!document.querySelector('input[name="share_consent"]:checked');
-      submitBtn.disabled = !(hasName && hasEmail && hasConsent);
+      submitBtn.disabled = !(hasName && hasEmail);
     }
 
-    document.querySelectorAll('input[name="share_consent"]').forEach(function(r) {
-      r.addEventListener('change', checkReady);
-    });
     emailInput.addEventListener('input', checkReady);
 
     nameText.addEventListener('input', function() {

--- a/reunion/templates/status.html
+++ b/reunion/templates/status.html
@@ -158,8 +158,7 @@
     return sortByResponse(people, type)
       .filter(p => p[type] !== 'no_response')
       .map(p => {
-        const showName = type === 'prov' ? p.prov_consent : p.final_consent;
-        const displayName = showName ? p.name : '<span class="text-muted">非公開</span>';
+        const displayName = p.name;
         return `<div class="person-row" data-prov="${p.prov}" data-final="${p.final}">
           <span class="flex-grow-1">${displayName}</span>
           <span class="badge person-badge ms-2"></span>


### PR DESCRIPTION
- 仮・本出欠フォームから共有許可ラジオボタンを削除
- forms.py: share_consent を常に True に固定（フォームからの取得廃止）
- status.html: 名前を常に表示（consent チェック撤廃）
- participant_detail.html: 名前共有トグルボタンを削除