### PR TITLE
仮出欠フォームにメール認証フローを追加

### DIFF
--- a/reunion/app.py
+++ b/reunion/app.py
@@ -66,7 +66,7 @@ def create_app():
     db.init_app(app)
 
     with app.app_context():
-        from models import Participant, ProvisionalResponse, FinalResponse, Payment, BankImport, MailLog, AppSetting
+        from models import Participant, ProvisionalResponse, FinalResponse, Payment, BankImport, MailLog, AppSetting, VerificationToken
         db.create_all()
         # カラム追加マイグレーション（既存DBへの追加カラム）
         _migrate(db)

--- a/reunion/models.py
+++ b/reunion/models.py
@@ -258,3 +258,28 @@ class MailLog(db.Model):
 
     def __repr__(self):
         return f"<MailLog {self.id}: participant={self.participant_id} type={self.mail_type} status={self.status}>"
+
+
+class VerificationToken(db.Model):
+    """
+    メール認証トークンテーブル
+    仮出欠フォーム送信後、メールアドレスの確認が完了するまで回答を保留する。
+    クリックで認証完了 → 回答を確定 + 確認メール送信。
+    """
+    __tablename__ = "verification_tokens"
+
+    id = db.Column(db.Integer, primary_key=True)
+    token = db.Column(db.String(64), unique=True, nullable=False, index=True)
+    participant_id = db.Column(db.Integer, db.ForeignKey("participants.id"), nullable=True)
+    # 新規参加者の場合（participant_id=None）のフォームデータを保持
+    form_name = db.Column(db.String(100), default="")
+    form_name_kana = db.Column(db.String(100), default="")
+    form_class_name = db.Column(db.String(50), default="")
+    new_email = db.Column(db.String(200), nullable=False)
+    prov_status = db.Column(db.String(20), nullable=False)
+    expires_at = db.Column(db.DateTime, nullable=False)
+    used_at = db.Column(db.DateTime, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def __repr__(self):
+        return f"<VerificationToken {self.id}: participant={self.participant_id} email={self.new_email}>"

--- a/reunion/routes/forms.py
+++ b/reunion/routes/forms.py
@@ -17,14 +17,15 @@ URL:
      c. 一致なし → 新規登録
 """
 import re
+import secrets
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from flask import Blueprint, render_template, request, redirect, url_for, flash, abort, current_app
 from extensions import db
-from models import Participant, ProvisionalResponse, FinalResponse, Payment
+from models import Participant, ProvisionalResponse, FinalResponse, Payment, VerificationToken
 from models import AppSetting
 from services.token_service import get_participant_by_token, ensure_token, generate_final_url
-from services.mail_service import send_provisional_confirmation, send_final_confirmation, send_cancel_confirmation
+from services.mail_service import send_provisional_confirmation, send_final_confirmation, send_cancel_confirmation, send_verification_email
 from utils import normalize_transfer_name, decompose_voiced
 
 logger = logging.getLogger(__name__)
@@ -131,41 +132,24 @@ def provisional():
                                class_name=class_name)
 
     matched_how = ""
+    participant = None
 
     # ── ステップ1: ドロップダウンで名簿IDが選択された場合（最優先）──
     if participant_id:
         participant = db.session.get(Participant, int(participant_id))
         if participant:
-            stored_email_real = participant.email and PLACEHOLDER_DOMAIN not in participant.email
-            already_responded = bool(participant.provisional_responses)
-
-            # 回答済み＆別メールアドレス → 別人による上書き試みをブロック
-            if already_responded and stored_email_real and participant.email != email:
-                flash(
-                    f"「{participant.name}」さんはすでに別のメールアドレスで回答済みです。"
-                    " ご本人のメールアドレスで再度ご回答いただくか、幹事にお問い合わせください。",
-                    "danger"
-                )
-                return render_template("provisional_form.html",
-                                       name=name, name_kana=name_kana,
-                                       email=email, status=status,
-                                       class_name=class_name)
-
             # 同じメールを持つ別の参加者が既にいるか確認
-            existing_by_email = Participant.query.filter_by(email=email).first()
-            if existing_by_email and existing_by_email.id != participant.id:
+            existing_by_email = Participant.query.filter(
+                Participant.email == email,
+                Participant.id != participant.id,
+                ~Participant.email.like(f"%{PLACEHOLDER_DOMAIN}"),
+            ).first()
+            if existing_by_email:
                 flash("このメールアドレスは既に別の方が登録済みです。ご自身のメールアドレスを入力してください。", "danger")
                 return render_template("provisional_form.html",
                                        name=name, name_kana=name_kana,
                                        email=email, status=status,
                                        class_name=class_name)
-            participant.email = email
-            # 既に名前が登録されている場合は上書きしない
-            if name and not participant.name:
-                participant.name = name
-            if name_kana and not participant.name_kana:
-                participant.name_kana = name_kana
-            participant.updated_at = datetime.utcnow()
             matched_how = "selected"
             name = participant.name
             logger.info(f"名簿選択: {participant.name} ({email})")
@@ -177,8 +161,6 @@ def provisional():
         participant = Participant.query.filter_by(email=email).first()
 
         if participant and PLACEHOLDER_DOMAIN not in participant.email:
-            # 名前は上書きせず登録済みの情報を保持する
-            participant.updated_at = datetime.utcnow()
             matched_how = "email"
             name = participant.name
             logger.info(f"既存参加者（メール一致）: {participant.name} ({email})")
@@ -187,49 +169,125 @@ def provisional():
             # ── ステップ3: 氏名で名簿を検索（名寄せ）──
             roster_match = _find_roster_match(name, class_name, student_number)
             if roster_match:
-                roster_match.email = email
-                roster_match.name  = name
-                if name_kana:
-                    roster_match.name_kana = name_kana
-                if class_name:
-                    roster_match.class_name = class_name
-                roster_match.updated_at = datetime.utcnow()
                 participant = roster_match
                 matched_how = "roster"
                 logger.info(f"名簿に名寄せ: {name} ({email}) → ID={roster_match.id}")
             else:
-                # ── ステップ4: 完全新規 ──
-                participant = Participant(name=name, email=email, class_name=class_name,
-                                          name_kana=name_kana)
-                db.session.add(participant)
-                db.session.flush()
+                # ── ステップ4: 完全新規（参加者はverify時に作成）──
+                participant = None
                 matched_how = "new"
-                logger.info(f"新規参加者登録: {name} ({email})")
+                logger.info(f"新規参加者（認証後登録）: {name} ({email})")
+
+        else:
+            # placeholder email で一致 → 名簿レコードとして扱う
+            matched_how = "roster"
+
+    # ── 認証トークン発行 ──
+    # 同一参加者の未使用トークンを無効化（再送の場合）
+    if participant:
+        VerificationToken.query.filter_by(
+            participant_id=participant.id, used_at=None
+        ).delete(synchronize_session=False)
+
+    vtk = VerificationToken(
+        token=secrets.token_urlsafe(32),
+        participant_id=participant.id if participant else None,
+        form_name=name,
+        form_name_kana=name_kana,
+        form_class_name=class_name,
+        new_email=email,
+        prov_status=status,
+        expires_at=datetime.utcnow() + timedelta(hours=24),
+    )
+    db.session.add(vtk)
+    db.session.commit()
+
+    logger.info(f"認証トークン発行: {name} ({email}) / 紐付け={matched_how}")
+
+    # 認証メールを送信
+    base_url = current_app.config.get("APP_BASE_URL", request.host_url.rstrip("/"))
+    verify_url = f"{base_url}/form/verify/{vtk.token}"
+    try:
+        send_verification_email(email, name, verify_url)
+    except Exception as e:
+        logger.error(f"認証メール送信エラー: {e}", exc_info=True)
+
+    return render_template("verify_pending.html", email=email, name=name)
+
+
+@forms_bp.route("/verify/<token>")
+def verify(token):
+    """メール認証リンクのクリック処理"""
+    vtk = VerificationToken.query.filter_by(token=token).first()
+
+    if not vtk:
+        return render_template("verify_error.html",
+                               message="このリンクは無効です。フォームから再度お試しください。",
+                               provisional_url=None)
+
+    if vtk.used_at:
+        return render_template("verify_complete.html", already_verified=True, participant=None)
+
+    if vtk.expires_at < datetime.utcnow():
+        return render_template("verify_error.html",
+                               message="このリンクは有効期限切れです（24時間）。フォームから再度ご登録ください。",
+                               expired=True,
+                               provisional_url=request.host_url.rstrip("/") + "/form/provisional")
+
+    # メールアドレスが他の参加者に取られていないか確認
+    existing_by_email = Participant.query.filter(
+        Participant.email == vtk.new_email,
+        ~Participant.email.like(f"%{PLACEHOLDER_DOMAIN}"),
+    ).first()
+    if existing_by_email and (vtk.participant_id is None or existing_by_email.id != vtk.participant_id):
+        return render_template("verify_error.html",
+                               message="このメールアドレスはすでに別の方が使用しています。別のメールアドレスでフォームから再登録してください。",
+                               provisional_url=request.host_url.rstrip("/") + "/form/provisional")
+
+    # 参加者を確定・作成
+    if vtk.participant_id:
+        participant = db.session.get(Participant, vtk.participant_id)
+        if participant is None:
+            return render_template("verify_error.html",
+                                   message="参加者情報が見つかりません。フォームから再度お試しください。",
+                                   provisional_url=request.host_url.rstrip("/") + "/form/provisional")
+        participant.email = vtk.new_email
+        participant.updated_at = datetime.utcnow()
+    else:
+        participant = Participant(
+            name=vtk.form_name,
+            name_kana=vtk.form_name_kana,
+            email=vtk.new_email,
+            class_name=vtk.form_class_name,
+        )
+        db.session.add(participant)
+        db.session.flush()
 
     # 仮出欠回答を追加
     response = ProvisionalResponse(
         participant_id=participant.id,
-        status=status,
+        status=vtk.prov_status,
         share_consent=True,
         submitted_at=datetime.utcnow(),
-        ip_address=request.remote_addr or "",
+        ip_address="",
     )
     db.session.add(response)
+
+    vtk.used_at = datetime.utcnow()
     db.session.commit()
 
-    logger.info(f"仮出欠登録完了: {name} / {status} / 紐付け={matched_how}")
+    logger.info(f"メール認証完了・回答確定: {participant.name} ({vtk.new_email}) → {vtk.prov_status}")
 
-    # 送信完了メールを送信（失敗してもフォーム送信はブロックしない）
+    # 確認メール送信
     try:
-        status_label = ProvisionalResponse.STATUS_LABELS.get(status, status)
+        status_label = ProvisionalResponse.STATUS_LABELS.get(vtk.prov_status, vtk.prov_status)
         base_url = current_app.config.get("APP_BASE_URL", request.host_url.rstrip("/"))
         provisional_url = f"{base_url}/form/provisional"
-        send_provisional_confirmation(participant, status_label, provisional_url, status)
+        send_provisional_confirmation(participant, status_label, provisional_url, vtk.prov_status)
     except Exception as e:
         logger.error(f"仮出欠確認メール送信エラー: {e}", exc_info=True)
 
-    flash("仮出欠を受け付けました。ありがとうございます。", "success")
-    return redirect(url_for("forms.done", type="provisional"))
+    return render_template("verify_complete.html", already_verified=False, participant=participant)
 
 
 def _today_jst():

--- a/reunion/services/mail_service.py
+++ b/reunion/services/mail_service.py
@@ -509,6 +509,22 @@ MAIL_DEFAULTS = {
         "──────────────────\n"
         "{reunion_name} 幹事代表 {organizer_name}"
     ),
+    # ── メールアドレス認証 ──────────────────────────────────
+    "mail_verification_subject": "【{reunion_name}】メールアドレスの認証をお願いします",
+    "mail_verification_body": (
+        "{name} 様\n\n"
+        "仮出欠フォームにご入力いただきありがとうございます。\n\n"
+        "メールアドレス・参加意思の登録はまだ完了していません。\n"
+        "下記URLをクリックして認証を完了させてください。\n\n"
+        "━━━━━━━━━━━━━━━━━━━━\n"
+        "■ 認証URL\n"
+        "━━━━━━━━━━━━━━━━━━━━\n"
+        "{verify_url}\n\n"
+        "※ このURLの有効期限は24時間です。\n"
+        "※ このメールに心当たりがない場合は、そのまま無視していただいて構いません。\n\n"
+        "──────────────────\n"
+        "{reunion_name} 幹事代表 {organizer_name}"
+    ),
     # ── 直前キャンセル確認 ──────────────────────────────────
     "mail_final_confirm_cancelled_subject": "【{reunion_name}】欠席のご連絡を受け付けました",
     "mail_final_confirm_cancelled_body": (
@@ -1077,6 +1093,28 @@ def send_provisional_reminder(participant, provisional_url: str) -> MailLog:
         raise
 
     return log
+
+
+def send_verification_email(to_email: str, name: str, verify_url: str) -> None:
+    """メールアドレス認証メールを送信する。MailLogには記録しない（参加者確定前のため）"""
+    mail_cfg = _get_mail_config()
+    reunion = _get_reunion_info()
+    vars = dict(
+        name=name,
+        verify_url=verify_url,
+        reunion_name=reunion["reunion_name"],
+        organizer_name=reunion["organizer_name"],
+    )
+    subject = _render_template(
+        _get_template("mail_verification_subject", MAIL_DEFAULTS["mail_verification_subject"]),
+        **vars
+    )
+    body = _render_template(
+        _get_template("mail_verification_body", MAIL_DEFAULTS["mail_verification_body"]),
+        **vars
+    )
+    _dispatch_send(to_email, subject, body, mail_cfg)
+    logger.info(f"認証メール送信: {to_email}")
 
 
 def send_provisional_confirmation(participant, status_label: str, provisional_url: str, status: str = "attending") -> MailLog:

--- a/reunion/templates/provisional_form.html
+++ b/reunion/templates/provisional_form.html
@@ -75,8 +75,17 @@
                 <select class="form-select" id="name_select">
                   <option value="">-- 名前を選択 --</option>
                 </select>
-                <div id="already_responded_msg" class="alert alert-warning py-2 mt-2 d-none" style="font-size:0.85rem;">
-                  ⚠️ この方はすでに回答済みです。同じ方が回答する場合はそのままお進みください。別の方の場合はお名前を選び直してください。
+                <div id="already_responded_msg" class="alert alert-warning mt-2 d-none" style="font-size:0.85rem;">
+                  <strong>⚠️ この方はすでに回答済みです。</strong><br>
+                  <span class="text-muted">ご本人の場合は、メールアドレスを入力してそのまま送信してください。</span>
+                  <div class="mt-2">
+                    <button type="button" class="btn btn-sm btn-outline-warning" id="change_email_btn">
+                      メールアドレスを変更して登録する
+                    </button>
+                  </div>
+                  <div id="change_email_note" class="d-none mt-2 text-muted" style="font-size:0.8rem;">
+                    新しいメールアドレスを入力して送信すると認証メールが届きます。認証後に登録内容が更新されます。
+                  </div>
                 </div>
               </div>
 
@@ -215,9 +224,21 @@ function checkReady() {
       checkReady();
     });
 
+    document.getElementById('change_email_btn').addEventListener('click', function() {
+      document.getElementById('change_email_note').classList.remove('d-none');
+      emailInput.value = '';
+      emailInput.focus();
+      emailInput.classList.add('border-warning');
+      emailInput.placeholder = '新しいメールアドレスを入力';
+      checkReady();
+    });
+
     nameSelect.addEventListener('change', function() {
       var val = nameSelect.value;
       document.getElementById('already_responded_msg').classList.add('d-none');
+      document.getElementById('change_email_note').classList.add('d-none');
+      emailInput.classList.remove('border-warning');
+      emailInput.placeholder = 'example@example.com';
       if (!val) {
         participantId.value = '';
         nameHidden.value = '';

--- a/reunion/templates/verify_complete.html
+++ b/reunion/templates/verify_complete.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>認証完了</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+  <div class="container py-5">
+    <div class="row justify-content-center">
+      <div class="col-md-6">
+        <div class="card shadow-sm">
+          <div class="card-header bg-success text-white text-center py-3">
+            <h4 class="mb-0">
+              {% if already_verified %}
+                <i class="bi bi-check-circle me-2"></i>認証済み
+              {% else %}
+                <i class="bi bi-check-circle-fill me-2"></i>認証完了
+              {% endif %}
+            </h4>
+          </div>
+          <div class="card-body p-4 text-center">
+            {% if already_verified %}
+              <div class="mb-4">
+                <i class="bi bi-check-all" style="font-size:3rem; color:#198754;"></i>
+              </div>
+              <h5 class="mb-3">このリンクはすでに使用済みです</h5>
+              <p class="text-muted">回答はすでに登録されています。</p>
+            {% else %}
+              <div class="mb-4">
+                <i class="bi bi-patch-check-fill" style="font-size:3rem; color:#198754;"></i>
+              </div>
+              <h5 class="mb-3">認証が完了しました！</h5>
+              {% if participant %}
+                <p class="text-muted mb-1">{{ participant.name }} さんの仮出欠が登録されました。</p>
+              {% endif %}
+              <p class="text-muted mb-4">確認メールをお送りしましたのでご確認ください。</p>
+              <div class="alert alert-success text-start" style="font-size:0.9rem;">
+                <i class="bi bi-envelope-check me-1"></i>
+                登録内容の確認メールを送信しました。<br>
+                届かない場合は迷惑メールフォルダもご確認ください。
+              </div>
+              <a href="/status" class="btn btn-outline-primary btn-sm mt-2 me-2">
+                <i class="bi bi-people me-1"></i>みんなの参加状況
+              </a>
+              <a href="/form/provisional" class="btn btn-outline-secondary btn-sm mt-2">
+                <i class="bi bi-arrow-repeat me-1"></i>回答を変更する
+              </a>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/reunion/templates/verify_error.html
+++ b/reunion/templates/verify_error.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>認証エラー</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+  <div class="container py-5">
+    <div class="row justify-content-center">
+      <div class="col-md-6">
+        <div class="card shadow-sm">
+          <div class="card-header bg-danger text-white text-center py-3">
+            <h4 class="mb-0"><i class="bi bi-exclamation-triangle me-2"></i>認証エラー</h4>
+          </div>
+          <div class="card-body p-4 text-center">
+            <div class="mb-4">
+              <i class="bi bi-x-circle-fill" style="font-size:3rem; color:#dc3545;"></i>
+            </div>
+            <p class="mb-4">{{ message }}</p>
+            {% if provisional_url %}
+              <a href="{{ provisional_url }}" class="btn btn-primary">
+                <i class="bi bi-arrow-left me-1"></i>フォームに戻る
+              </a>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/reunion/templates/verify_pending.html
+++ b/reunion/templates/verify_pending.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>認証メールを送信しました</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+  <div class="container py-5">
+    <div class="row justify-content-center">
+      <div class="col-md-6">
+        <div class="card shadow-sm">
+          <div class="card-header bg-warning text-dark text-center py-3">
+            <h4 class="mb-0"><i class="bi bi-envelope-check me-2"></i>認証メールを送信しました</h4>
+          </div>
+          <div class="card-body p-4 text-center">
+            <div class="mb-4">
+              <i class="bi bi-envelope-paper" style="font-size:3rem; color:#ffc107;"></i>
+            </div>
+            <h5 class="mb-3">メールアドレスの確認が必要です</h5>
+            <p class="text-muted mb-1">以下のアドレスに認証メールをお送りしました。</p>
+            <p class="fw-bold mb-4">{{ email }}</p>
+            <div class="alert alert-info text-start" style="font-size:0.9rem;">
+              <strong>メール本文にある認証URLをクリック</strong>して、<br>
+              回答の登録を完了させてください。<br><br>
+              <i class="bi bi-clock me-1"></i>認証URLの有効期限は<strong>24時間</strong>です。<br>
+              <i class="bi bi-envelope-x me-1"></i>メールが届かない場合は<strong>迷惑メールフォルダ</strong>もご確認ください。<br>
+              <i class="bi bi-arrow-repeat me-1"></i>期限切れの場合は
+              <a href="/form/provisional">フォームから再度送信</a>してください。
+            </div>
+            <a href="/form/provisional" class="btn btn-outline-secondary btn-sm mt-2">
+              <i class="bi bi-arrow-left me-1"></i>フォームに戻る
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
- フォーム送信時に確認メールを直接送らず認証トークンを発行
- 認証メール（verify_url）をクリックして初めて回答確定・確認メール送信
- VerificationTokenモデル追加（24時間有効・使い捨て）
- メアド変更も同じフローで対応（別メールで認証→上書き）
- 回答済み名前選択時に「メアドを変更して登録する」ボタンを表示
- 認証メールテンプレートをMAIL_DEFAULTSに追加（管理画面から編集可）