### PR TITLE
UI改善: クラス別名簿・円グラフ切替・下部ナビ・名簿への組-番表示

### DIFF
--- a/reunion/app.py
+++ b/reunion/app.py
@@ -142,6 +142,7 @@ def create_app():
 
             is_teacher = p.role in TEACHER_ROLES
             info = {"name": p.name + (" 先生" if is_teacher else ""), "prov": ps, "final": fs,
+                    "class_name": p.class_name or "", "number": p.student_number or "",
                     "prov_consent": prov_consent, "final_consent": final_consent,
                     "prov_at": prov.submitted_at.isoformat() if prov else None,
                     "final_at": final.submitted_at.isoformat() if final else None}
@@ -172,18 +173,16 @@ def create_app():
         from models import AttendanceRecord, Participant
         from services.mail_service import send_attendance_confirmation
 
-        participants = Participant.query.order_by(Participant.name).all()
-
         if request.method == "POST":
             participant_id = request.form.get("participant_id", "").strip()
             if not participant_id:
                 flash("参加者を選択してください。", "warning")
-                return render_template("attendance_scan.html", participants=participants)
+                return render_template("attendance_scan.html")
 
             participant = Participant.query.get(participant_id)
             if not participant:
                 flash("参加者が見つかりませんでした。", "danger")
-                return render_template("attendance_scan.html", participants=participants)
+                return render_template("attendance_scan.html")
 
             # 重複チェックを行わず、登録を追加する（当日制限はなし）
             record = AttendanceRecord(participant_id=participant.id, source="qr")
@@ -203,7 +202,7 @@ def create_app():
 
             return render_template("attendance_done.html", participant=participant)
 
-        return render_template("attendance_scan.html", participants=participants)
+        return render_template("attendance_scan.html")
 
     # -----------------------------------------------
     # エラーハンドラ

--- a/reunion/routes/admin.py
+++ b/reunion/routes/admin.py
@@ -145,13 +145,64 @@ def index():
 @admin_bp.route("/qr-attendance")
 def qr_attendance():
     """会場QR出席の管理画面"""
-    participants = Participant.query.order_by(Participant.name).all()
+    # 名簿CSVの読み込み順（DB登録順: created_at）を保ちつつクラス順に表示
+    participants = Participant.query.order_by(Participant.class_name, Participant.created_at).all()
     records = AttendanceRecord.query.order_by(AttendanceRecord.checked_in_at.desc()).all()
     qr_url = url_for("attendance_scan", _external=True)
     total = len(participants)
     checked_ids = {r.participant_id for r in records if r.status == "checked_in"}
     checked_count = len(checked_ids)
     not_checked = max(0, total - checked_count)
+
+    # クラス別名簿（幹事用）: 本出欠参加・来場済み・未来場を名前順で一覧化
+    latest_checkin = {}
+    for r in records:  # records は checked_in_at 降順
+        if r.status == "checked_in" and r.participant_id not in latest_checkin:
+            latest_checkin[r.participant_id] = r
+
+    def _member_info(p):
+        final = p.latest_final
+        rec = latest_checkin.get(p.id)
+        return {
+            "participant": p,
+            "final_attending": bool(final and final.status == "attending"),
+            "final_status": final.status if final else None,
+            "checked_in": rec is not None,
+            "checked_in_at": rec.checked_in_at if rec else None,
+        }
+
+    def _kana_key(p):
+        return (p.name_kana or p.name or "")
+
+    roster = []
+    for key in [str(n) for n in range(31, 40)]:
+        members = sorted(
+            [p for p in participants
+             if p.class_name == key and p.role in ("生徒", "幹事")],
+            key=_kana_key,
+        )
+        infos = [_member_info(p) for p in members]
+        roster.append({
+            "key": key,
+            "label": key,
+            "members": infos,
+            "attending_count": sum(1 for m in infos if m["final_attending"]),
+            "arrived_count": sum(1 for m in infos if m["checked_in"]),
+            "pending_count": sum(1 for m in infos if m["final_attending"] and not m["checked_in"]),
+        })
+    teachers = sorted(
+        [p for p in participants if p.role in ("教師", "学年主任")],
+        key=_kana_key,
+    )
+    teacher_infos = [_member_info(p) for p in teachers]
+    roster.append({
+        "key": "teacher",
+        "label": "教職員",
+        "members": teacher_infos,
+        "attending_count": sum(1 for m in teacher_infos if m["final_attending"]),
+        "arrived_count": sum(1 for m in teacher_infos if m["checked_in"]),
+        "pending_count": sum(1 for m in teacher_infos if m["final_attending"] and not m["checked_in"]),
+    })
 
     return render_template(
         "admin/qr_attendance.html",
@@ -161,6 +212,7 @@ def qr_attendance():
         total=total,
         checked_count=checked_count,
         not_checked=not_checked,
+        roster=roster,
     )
 
 
@@ -808,7 +860,8 @@ def api_mail_preview(mail_type):
         "body": body_tmpl,
         "html_body": _text_to_html(body_tmpl),
         "targets": [
-            {"id": p.id, "name": p.name, "email": p.email, "role": p.role or ""}
+            {"id": p.id, "name": p.name, "email": p.email, "role": p.role or "",
+             "class_name": p.class_name or "", "number": p.student_number or ""}
             for p in targets
         ],
         "target_count": len(targets),

--- a/reunion/static/css/style.css
+++ b/reunion/static/css/style.css
@@ -48,3 +48,54 @@ body {
 footer {
   font-size: 0.8rem;
 }
+
+/* 下部ナビ（スマホアプリ風） */
+body {
+  padding-bottom: calc(64px + env(safe-area-inset-bottom));
+}
+
+.app-bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1030;
+  display: flex;
+  background: #fff;
+  border-top: 1px solid #dee2e6;
+  padding-bottom: env(safe-area-inset-bottom);
+  box-shadow: 0 -2px 10px rgba(0, 0, 0, .06);
+}
+
+.app-bottom-nav .bottom-nav-item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 8px 0 6px;
+  font-size: 0.65rem;
+  color: #6c757d;
+  text-decoration: none;
+  border: none;
+  background: none;
+}
+
+.app-bottom-nav .bottom-nav-item i {
+  font-size: 1.35rem;
+  line-height: 1;
+}
+
+.app-bottom-nav .bottom-nav-item.active {
+  color: #0d6efd;
+}
+
+.app-bottom-nav .bottom-nav-home i {
+  font-size: 1.6rem;
+}
+
+.register-sheet {
+  height: auto;
+  max-height: 60vh;
+  border-radius: 16px 16px 0 0;
+}

--- a/reunion/templates/admin/index.html
+++ b/reunion/templates/admin/index.html
@@ -41,53 +41,57 @@
 <h4 class="mb-4"><i class="bi bi-speedometer2 me-2"></i>ダッシュボード</h4>
 
 <div class="row g-4 mb-4">
-  <!-- 仮出欠 -->
-  <div class="col-12 col-md-4">
-    <div class="card border-0 shadow-sm h-100 chart-card">
+  <!-- 円グラフ（タップで 仮出欠 / 本出欠 / 入金 を切り替え） -->
+  <div class="col-12 col-md-8 col-lg-6 mx-auto">
+    <div class="card border-0 shadow-sm chart-card">
       <div class="card-body text-center">
-        <h6 class="text-muted mb-3">仮出欠</h6>
-        <div class="chart-wrap">
-          <canvas id="chartProvisional"></canvas>
-          <div class="chart-center">
-            <div class="num">{{ stats.total }}</div>
-            <div class="label">登録者数</div>
+        <div class="d-flex justify-content-center mb-3">
+          <div class="btn-group btn-group-sm" role="group" id="chartTabs">
+            <button type="button" class="btn btn-primary" data-pane="paneProvisional" data-chart="provisional">仮出欠</button>
+            <button type="button" class="btn btn-outline-primary" data-pane="paneFinal" data-chart="final">本出欠</button>
+            <button type="button" class="btn btn-outline-primary" data-pane="panePayment" data-chart="payment">入金</button>
           </div>
         </div>
-        <ul class="chart-legend" id="legendProvisional"></ul>
-      </div>
-    </div>
-  </div>
 
-  <!-- 本出欠 -->
-  <div class="col-12 col-md-4">
-    <div class="card border-0 shadow-sm h-100 chart-card">
-      <div class="card-body text-center">
-        <h6 class="text-muted mb-3">本出欠</h6>
-        <div class="chart-wrap">
-          <canvas id="chartFinal"></canvas>
-          <div class="chart-center">
-            <div class="num">{{ stats.total }}</div>
-            <div class="label">登録者数</div>
+        <!-- 仮出欠 -->
+        <div id="paneProvisional" class="chart-pane">
+          <div class="chart-wrap">
+            <canvas id="chartProvisional"></canvas>
+            <div class="chart-center">
+              <div class="num">{{ stats.total }}</div>
+              <div class="label">登録者数</div>
+            </div>
           </div>
+          <ul class="chart-legend" id="legendProvisional"></ul>
         </div>
-        <ul class="chart-legend" id="legendFinal"></ul>
-      </div>
-    </div>
-  </div>
 
-  <!-- 入金 -->
-  <div class="col-12 col-md-4">
-    <div class="card border-0 shadow-sm h-100 chart-card">
-      <div class="card-body text-center">
-        <h6 class="text-muted mb-3">入金</h6>
-        <div class="chart-wrap">
-          <canvas id="chartPayment"></canvas>
-          <div class="chart-center">
-            <div class="num">{{ stats.paid + stats.unpaid }}</div>
-            <div class="label">対象者数</div>
+        <!-- 本出欠 -->
+        <div id="paneFinal" class="chart-pane d-none">
+          <div class="chart-wrap">
+            <canvas id="chartFinal"></canvas>
+            <div class="chart-center">
+              <div class="num">{{ stats.total }}</div>
+              <div class="label">登録者数</div>
+            </div>
           </div>
+          <ul class="chart-legend" id="legendFinal"></ul>
         </div>
-        <ul class="chart-legend" id="legendPayment"></ul>
+
+        <!-- 入金 -->
+        <div id="panePayment" class="chart-pane d-none">
+          <div class="chart-wrap">
+            <canvas id="chartPayment"></canvas>
+            <div class="chart-center">
+              <div class="num">{{ stats.paid + stats.unpaid }}</div>
+              <div class="label">対象者数</div>
+            </div>
+          </div>
+          <ul class="chart-legend" id="legendPayment"></ul>
+        </div>
+
+        <a href="{{ url_for('status', detail=1) }}" target="_blank" class="btn btn-outline-secondary btn-sm mt-3">
+          <i class="bi bi-bar-chart-fill me-1"></i>参加状況を内訳付きで見る
+        </a>
       </div>
     </div>
   </div>
@@ -362,8 +366,10 @@
     return chart;
   }
 
+  var charts = {};
+
   // 仮出欠
-  createDoughnut('chartProvisional', 'legendProvisional', [
+  charts.provisional = createDoughnut('chartProvisional', 'legendProvisional', [
     { label: '仮参加',   value: {{ stats.provisional_attending }},     color: '#198754', url: URLS.participants + '?status=attending' },
     { label: '仮不参加', value: {{ stats.provisional_not_attending }}, color: '#adb5bd', url: URLS.participants + '?status=not_attending' },
     { label: '仮未定',   value: {{ stats.provisional_undecided }},     color: '#0dcaf0', url: URLS.participants + '?status=undecided' },
@@ -371,17 +377,35 @@
   ]);
 
   // 本出欠
-  createDoughnut('chartFinal', 'legendFinal', [
+  charts.final = createDoughnut('chartFinal', 'legendFinal', [
     { label: '本参加',   value: {{ stats.final_attending }},     color: '#198754', url: URLS.participants + '?final_status=attending' },
     { label: '本不参加', value: {{ stats.final_not_attending }}, color: '#adb5bd', url: URLS.participants + '?final_status=not_attending' },
     { label: '未回答',   value: {{ stats.final_no_response }},   color: '#ffc107', url: URLS.participants + '?final_status=no_response' }
   ]);
 
   // 入金
-  createDoughnut('chartPayment', 'legendPayment', [
+  charts.payment = createDoughnut('chartPayment', 'legendPayment', [
     { label: '入金済み', value: {{ stats.paid }},   color: '#198754', url: URLS.payments + '?status=paid' },
     { label: '未入金',   value: {{ stats.unpaid }}, color: '#dc3545', url: URLS.payments + '?status=unpaid' }
   ]);
+
+  // 円グラフのタブ切り替え
+  var tabButtons = document.querySelectorAll('#chartTabs button');
+  tabButtons.forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      tabButtons.forEach(function(b) {
+        b.classList.remove('btn-primary');
+        b.classList.add('btn-outline-primary');
+        document.getElementById(b.dataset.pane).classList.add('d-none');
+      });
+      btn.classList.remove('btn-outline-primary');
+      btn.classList.add('btn-primary');
+      document.getElementById(btn.dataset.pane).classList.remove('d-none');
+      // 非表示中に生成したチャートはサイズ0のままなので再計算する
+      var chart = charts[btn.dataset.chart];
+      if (chart) chart.resize();
+    });
+  });
 })();
 
   // フォームロックトグル

--- a/reunion/templates/admin/mail_hub.html
+++ b/reunion/templates/admin/mail_hub.html
@@ -137,6 +137,7 @@
               <thead class="table-light sticky-top">
                 <tr>
                   <th>#</th>
+                  <th>組-番</th>
                   <th>名前</th>
                   <th>メールアドレス</th>
                 </tr>
@@ -264,8 +265,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
           data.targets.forEach(function(t, i) {
             const roleLabel = t.role && t.role !== '生徒' ? `<span class="badge bg-secondary ms-1">${t.role}</span>` : '';
+            const classNum = (t.class_name || '-') + (t.number ? '-' + t.number : '');
             const tr = document.createElement('tr');
             tr.innerHTML = `<td class="text-muted small">${i + 1}</td>` +
+              `<td class="text-muted small text-nowrap">${classNum}</td>` +
               `<td>${t.name}${roleLabel}</td>` +
               `<td class="small text-muted">${t.email}</td>`;
             tbody.appendChild(tr);

--- a/reunion/templates/admin/participants.html
+++ b/reunion/templates/admin/participants.html
@@ -25,36 +25,34 @@
   <!-- ========== 参加者一覧タブ ========== -->
   <div class="tab-pane fade show active" id="listPane" role="tabpanel">
 
-<div class="d-flex flex-column flex-md-row justify-content-between align-items-start gap-2 mb-3">
-  <div class="d-flex gap-2 align-items-center">
-    <form class="d-flex gap-1" method="GET">
-      <input type="hidden" name="sort" value="{{ sort }}">
-      <input type="hidden" name="order" value="{{ order }}">
-      <input type="hidden" name="status" value="{{ status_filter }}">
-      <input type="hidden" name="final_status" value="{{ final_filter }}">
-      <input type="hidden" name="role" value="{{ role_filter }}">
-      <input type="hidden" name="class_name" value="{{ class_filter }}">
-      <input type="text" class="form-control form-control-sm" name="q"
-             value="{{ q }}" placeholder="氏名・メールで検索" style="width:180px;">
-      <button type="submit" class="btn btn-outline-primary btn-sm"><i class="bi bi-search"></i></button>
-      {% if q %}
-      <a href="{{ url_for('admin.participants', sort=sort, order=order, status=status_filter, final_status=final_filter, role=role_filter, class_name=class_filter) }}"
-         class="btn btn-outline-secondary btn-sm" title="検索クリア"><i class="bi bi-x-lg"></i></a>
-      {% endif %}
-    </form>
-  </div>
-  <div class="d-flex flex-wrap gap-2 align-items-center">
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-3">
+  <form class="d-flex gap-1 participant-search" method="GET">
+    <input type="hidden" name="sort" value="{{ sort }}">
+    <input type="hidden" name="order" value="{{ order }}">
+    <input type="hidden" name="status" value="{{ status_filter }}">
+    <input type="hidden" name="final_status" value="{{ final_filter }}">
+    <input type="hidden" name="role" value="{{ role_filter }}">
+    <input type="hidden" name="class_name" value="{{ class_filter }}">
+    <input type="text" class="form-control form-control-sm" name="q"
+           value="{{ q }}" placeholder="氏名・メールで検索" style="width:180px;">
+    <button type="submit" class="btn btn-outline-primary btn-sm"><i class="bi bi-search"></i></button>
+    {% if q %}
+    <a href="{{ url_for('admin.participants', sort=sort, order=order, status=status_filter, final_status=final_filter, role=role_filter, class_name=class_filter) }}"
+       class="btn btn-outline-secondary btn-sm" title="検索クリア"><i class="bi bi-x-lg"></i></a>
+    {% endif %}
+  </form>
+  <div class="participant-actions">
     <a href="{{ url_for('admin.roster_export') }}" class="btn btn-outline-secondary btn-sm">
       <i class="bi bi-download me-1"></i>CSVエクスポート
     </a>
     <a href="{{ url_for('admin.mail_hub') }}?type=final_url" class="btn btn-success btn-sm">
-      <i class="bi bi-envelope-fill me-1"></i>本出欠URL一括送信
+      <i class="bi bi-envelope-fill me-1"></i><span class="d-none d-md-inline">本出欠URL一括送信</span><span class="d-md-none">本出欠URL送信</span>
     </a>
     <a href="{{ url_for('admin.mail_hub') }}?type=reminder" class="btn btn-primary btn-sm">
-      <i class="bi bi-bell-fill me-1"></i>本出欠リマインド一括送信
+      <i class="bi bi-bell-fill me-1"></i><span class="d-none d-md-inline">本出欠リマインド一括送信</span><span class="d-md-none">リマインド送信</span>
     </a>
     <a href="{{ url_for('admin.mail_hub') }}?type=final_reminder" class="btn btn-danger btn-sm">
-      <i class="bi bi-file-earmark-pdf me-1"></i>最終リマインド一括送信
+      <i class="bi bi-file-earmark-pdf me-1"></i><span class="d-none d-md-inline">最終リマインド一括送信</span><span class="d-md-none">最終リマインド</span>
     </a>
   </div>
 </div>
@@ -65,6 +63,17 @@
   .th-filter { white-space:nowrap; }
   .th-filter a { text-decoration:none; color:inherit; }
   .filter-active { color:#0d6efd !important; }
+  /* 氏名などのセル内改行を防ぎ、はみ出す分は横スクロールさせる */
+  #listPane .table td { white-space:nowrap; }
+  /* 操作ボタン: スマホは2×2グリッド、md以上は右寄せ横並び */
+  .participant-actions { display:grid; grid-template-columns:1fr 1fr; gap:.5rem; }
+  .participant-actions .btn { white-space:nowrap; }
+  @media (min-width: 768px) {
+    .participant-actions { display:flex; flex-wrap:wrap; justify-content:flex-end; }
+  }
+  @media (max-width: 767.98px) {
+    .participant-search input[name="q"] { flex:1; width:auto !important; }
+  }
 </style>
 
 <!-- 参加者テーブル -->
@@ -72,10 +81,7 @@
   <table class="table table-hover table-sm align-middle">
     <thead class="table-light">
       <tr>
-        <th>ID</th>
-        <th class="th-filter">
-          <a href="{{ sort_url('name') }}">氏名 <i class="bi {{ sort_icon('name') }}"></i></a>
-        </th>
+        <th class="d-none d-md-table-cell">ID</th>
         <th class="th-filter">
           <div class="dropdown d-inline">
             <a href="#" class="dropdown-toggle {{ 'filter-active' if class_filter != 'all' }}"
@@ -96,6 +102,9 @@
         </th>
         <th class="th-filter">
           <a href="{{ sort_url('number') }}">番号 <i class="bi {{ sort_icon('number') }}"></i></a>
+        </th>
+        <th class="th-filter">
+          <a href="{{ sort_url('name') }}">氏名 <i class="bi {{ sort_icon('name') }}"></i></a>
         </th>
         <th class="th-filter">
           <div class="dropdown d-inline">
@@ -119,7 +128,7 @@
           </div>
           <a href="{{ sort_url('role') }}"><i class="bi {{ sort_icon('role') }}"></i></a>
         </th>
-        <th><a href="{{ sort_url('email') }}" class="text-decoration-none text-dark">メール <i class="bi {{ sort_icon('email') }}"></i></a></th>
+        <th class="d-none d-md-table-cell"><a href="{{ sort_url('email') }}" class="text-decoration-none text-dark">メール <i class="bi {{ sort_icon('email') }}"></i></a></th>
         <th class="th-filter">
           <div class="dropdown d-inline">
             <a href="#" class="dropdown-toggle {{ 'filter-active' if status_filter != 'all' }}"
@@ -174,7 +183,7 @@
           </div>
         </th>
         <th>入金</th>
-        <th><a href="{{ sort_url('created') }}" class="text-decoration-none text-dark">
+        <th class="d-none d-md-table-cell"><a href="{{ sort_url('created') }}" class="text-decoration-none text-dark">
           登録日 <i class="bi {{ sort_icon('created') }}"></i></a></th>
         <th>詳細</th>
       </tr>
@@ -184,19 +193,19 @@
       {% set prov = p.latest_provisional %}
       {% set final = p.latest_final %}
       <tr>
-        <td class="text-muted small">{{ p.id }}</td>
+        <td class="text-muted small d-none d-md-table-cell">{{ p.id }}</td>
+        <td class="small text-center">{{ p.class_name or '' }}</td>
+        <td class="small text-center">{{ p.student_number or '' }}</td>
         <td>
           {{ p.display_name }}
         </td>
-        <td class="small text-center">{{ p.class_name or '' }}</td>
-        <td class="small text-center">{{ p.student_number or '' }}</td>
         <td class="small">
           {% if p.role == '教師' %}<span class="badge bg-warning text-dark">教師</span>
           {% elif p.role == '学年主任' %}<span class="badge bg-danger">学年主任</span>
           {% elif p.role == '幹事' %}<span class="badge bg-info text-dark">幹事</span>
           {% else %}<span class="badge bg-primary">生徒</span>{% endif %}
         </td>
-        <td class="small">
+        <td class="small d-none d-md-table-cell">
           {% if p.email and '@placeholder.local' not in p.email %}{{ p.email }}
           {% else %}<span class="text-muted">未登録</span>{% endif %}
         </td>
@@ -230,7 +239,7 @@
             <span class="text-muted small">-</span>
           {% endif %}
         </td>
-        <td class="small text-muted">{{ p.created_at | jst('%m/%d') }}</td>
+        <td class="small text-muted d-none d-md-table-cell">{{ p.created_at | jst('%m/%d') }}</td>
         <td>
           <a href="{{ url_for('admin.participant_detail', participant_id=p.id) }}"
              class="btn btn-outline-primary btn-sm">詳細</a>

--- a/reunion/templates/admin/payments.html
+++ b/reunion/templates/admin/payments.html
@@ -67,6 +67,7 @@
       <table class="table table-hover table-sm align-middle">
         <thead class="table-light">
           <tr>
+            <th>組-番</th>
             <th>氏名</th>
             <th>ステータス</th>
             <th>予定金額</th>
@@ -80,6 +81,9 @@
         <tbody>
           {% for payment in payments %}
           <tr>
+            <td class="small text-muted text-nowrap">
+              {{ payment.participant.class_name or '-' }}{% if payment.participant.student_number %}-{{ payment.participant.student_number }}{% endif %}
+            </td>
             <td>
               <a href="{{ url_for('admin.participant_detail', participant_id=payment.participant_id) }}">
                 {{ payment.participant.name }}
@@ -158,7 +162,7 @@
           </div>
           {% else %}
           <tr>
-            <td colspan="8" class="text-center text-muted py-4">入金レコードがありません</td>
+            <td colspan="9" class="text-center text-muted py-4">入金レコードがありません</td>
           </tr>
           {% endfor %}
         </tbody>

--- a/reunion/templates/admin/qr_attendance.html
+++ b/reunion/templates/admin/qr_attendance.html
@@ -12,6 +12,38 @@
 
   <div class="row g-4">
     <div class="col-lg-5">
+      <div class="card border-0 shadow-sm mb-4">
+        <div class="card-body">
+          <h5 class="mb-3">会場出席登録</h5>
+          <div class="mb-3">
+            <label for="class_select" class="form-label fw-bold">クラス <span class="text-danger">*</span></label>
+            <select class="form-select" id="class_select">
+              <option value="">-- クラスを選択 --</option>
+              <option value="31">31</option>
+              <option value="32">32</option>
+              <option value="33">33</option>
+              <option value="34">34</option>
+              <option value="35">35</option>
+              <option value="36">36</option>
+              <option value="37">37</option>
+              <option value="38">38</option>
+              <option value="39">39</option>
+              <option value="teacher">教職員</option>
+            </select>
+          </div>
+          <div class="mb-3 d-none" id="name_select_group">
+            <label for="name_select" class="form-label fw-bold">お名前 <span class="text-danger">*</span></label>
+            <select class="form-select" id="name_select" disabled>
+              <option value="">-- 名前を選択 --</option>
+            </select>
+          </div>
+          <form method="post" id="checkin_form" action="">
+            <input type="hidden" name="status" value="checked_in">
+            <button type="submit" class="btn btn-success w-100" id="checkin_btn" disabled>出席登録する</button>
+          </form>
+        </div>
+      </div>
+
       <div class="card border-0 shadow-sm">
         <div class="card-body">
           <h5 class="mb-3">QRコード</h5>
@@ -28,6 +60,104 @@
     </div>
 
     <div class="col-lg-7">
+      <div class="card border-0 shadow-sm mb-4">
+        <div class="card-body">
+          <div class="d-flex justify-content-between align-items-center mb-1">
+            <h5 class="mb-0">クラス別名簿（幹事用）</h5>
+          </div>
+          <p class="text-muted small mb-3">自分のクラスを選ぶと、参加予定・来場済み・まだの人が名前順で確認できます。</p>
+
+          <ul class="nav nav-pills flex-wrap gap-1 mb-3" id="rosterTabs" role="tablist">
+            {% for cls in roster %}
+            <li class="nav-item" role="presentation">
+              <button class="nav-link px-3 py-1 {% if loop.first %}active{% endif %}"
+                      data-bs-toggle="pill" data-bs-target="#roster-{{ cls.key }}" type="button" role="tab">
+                {{ cls.label }}
+              </button>
+            </li>
+            {% endfor %}
+          </ul>
+
+          <div class="tab-content">
+            {% for cls in roster %}
+            <div class="tab-pane fade {% if loop.first %}show active{% endif %}" id="roster-{{ cls.key }}" role="tabpanel">
+              <div class="d-flex flex-wrap gap-2 mb-2 align-items-center">
+                <span class="badge bg-primary-subtle text-primary border">参加予定 {{ cls.attending_count }}</span>
+                <span class="badge bg-success-subtle text-success border">来場済み {{ cls.arrived_count }}</span>
+                <span class="badge bg-warning-subtle text-warning-emphasis border">まだ {{ cls.pending_count }}</span>
+                <div class="btn-group btn-group-sm ms-auto roster-filter" data-target="roster-{{ cls.key }}">
+                  <button type="button" class="btn btn-outline-secondary active" data-filter="all">全員</button>
+                  <button type="button" class="btn btn-outline-secondary" data-filter="attending">参加予定</button>
+                  <button type="button" class="btn btn-outline-secondary" data-filter="arrived">来場済み</button>
+                  <button type="button" class="btn btn-outline-secondary" data-filter="pending">まだ</button>
+                </div>
+              </div>
+              {% if cls.members %}
+              <div class="table-responsive">
+                <table class="table table-sm align-middle mb-0">
+                  <thead>
+                    <tr>
+                      <th>組-番</th>
+                      <th>名前</th>
+                      <th>本出欠</th>
+                      <th>当日</th>
+                      <th>操作</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for m in cls.members %}
+                    {% set p = m.participant %}
+                    <tr class="{% if m.checked_in %}table-success{% elif not m.final_attending %}text-muted{% endif %}"
+                        data-attending="{{ 1 if m.final_attending else 0 }}"
+                        data-arrived="{{ 1 if m.checked_in else 0 }}">
+                      <td class="small text-muted text-nowrap">
+                        {{ p.class_name or '-' }}{% if p.student_number %}-{{ p.student_number }}{% endif %}
+                      </td>
+                      <td>
+                        {{ p.name }}{% if p.role in ['教師', '学年主任'] %} 先生{% endif %}
+                        {% if p.name_kana %}<span class="small text-muted ms-1">{{ p.name_kana }}</span>{% endif %}
+                      </td>
+                      <td>
+                        {% if m.final_attending %}
+                          <span class="badge bg-primary">参加</span>
+                        {% elif m.final_status in ['not_attending', 'cancelled'] %}
+                          <span class="badge bg-secondary">不参加</span>
+                        {% else %}
+                          <span class="badge bg-warning text-dark">未回答</span>
+                        {% endif %}
+                      </td>
+                      <td>
+                        {% if m.checked_in %}
+                          <span class="text-success fw-bold"><i class="bi bi-check-circle-fill me-1"></i>来場済み</span>
+                          {% if m.checked_in_at %}<span class="small text-muted ms-1">{{ m.checked_in_at.strftime('%H:%M') }}</span>{% endif %}
+                        {% elif m.final_attending %}
+                          <span class="text-warning-emphasis"><i class="bi bi-clock me-1"></i>まだ</span>
+                        {% else %}
+                          <span class="text-muted">-</span>
+                        {% endif %}
+                      </td>
+                      <td>
+                        {% if not m.checked_in %}
+                        <form method="post" action="{{ url_for('admin.set_attendance', participant_id=p.id) }}" class="d-inline">
+                          <input type="hidden" name="status" value="checked_in">
+                          <button class="btn btn-sm btn-outline-success" type="submit">出席登録</button>
+                        </form>
+                        {% endif %}
+                      </td>
+                    </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+              {% else %}
+              <div class="text-muted small">このクラスの名簿はありません。</div>
+              {% endif %}
+            </div>
+            {% endfor %}
+          </div>
+        </div>
+      </div>
+
       <div class="card border-0 shadow-sm">
         <div class="card-body">
           <h5 class="mb-3">登録結果一覧</h5>
@@ -50,6 +180,7 @@
             <table class="table table-sm align-middle">
               <thead>
                 <tr>
+                  <th>組-番</th>
                   <th>参加者</th>
                   <th>登録時刻</th>
                   <th>状態</th>
@@ -60,7 +191,12 @@
               <tbody>
                 {% for record in records %}
                 <tr>
-                  <td>{{ record.participant.name }}</td>
+                  <td class="small text-muted text-nowrap">
+                    {{ record.participant.class_name or '-' }}{% if record.participant.student_number %}-{{ record.participant.student_number }}{% endif %}
+                  </td>
+                  <td>
+                    {{ record.participant.name }}{% if record.participant.role in ['教師', '学年主任'] %}先生{% endif %}
+                  </td>
                   <td>{{ record.checked_in_at.strftime('%Y/%m/%d %H:%M') }}</td>
                   <td><span class="badge bg-success">登録済み</span></td>
                   <td>{% if record.email_sent %}送信済み{% else %}未送信{% endif %}</td>
@@ -88,3 +224,72 @@
   </div>
 </div>
 {% endblock %}
+
+{% block extra_js %}
+<script>
+  const classSelect     = document.getElementById('class_select');
+  const nameSelectGroup = document.getElementById('name_select_group');
+  const nameSelect      = document.getElementById('name_select');
+  const checkinForm     = document.getElementById('checkin_form');
+  const checkinBtn      = document.getElementById('checkin_btn');
+
+  classSelect.addEventListener('change', async function() {
+    const cls = classSelect.value;
+    nameSelect.innerHTML = '<option value="">読み込み中...</option>';
+    nameSelect.disabled = true;
+    checkinBtn.disabled = true;
+    checkinForm.action = '';
+
+    if (!cls) {
+      nameSelectGroup.classList.add('d-none');
+      return;
+    }
+
+    nameSelectGroup.classList.remove('d-none');
+    const res = await fetch("{{ url_for('forms.api_names') }}?class=" + cls);
+    const names = await res.json();
+
+    nameSelect.innerHTML = '<option value="">-- 名前を選択 --</option>';
+    names.forEach(function(p) {
+      const opt = document.createElement('option');
+      opt.value = p.id;
+      const isTeacher = p.role === '教師' || p.role === '学年主任';
+      opt.textContent = isTeacher ? p.name + ' 先生' : p.name;
+      nameSelect.appendChild(opt);
+    });
+    nameSelect.disabled = false;
+  });
+
+  nameSelect.addEventListener('change', function() {
+    const pid = nameSelect.value;
+    if (pid) {
+      checkinForm.action = '/admin/participant/' + pid + '/set-attendance';
+      checkinBtn.disabled = false;
+    } else {
+      checkinForm.action = '';
+      checkinBtn.disabled = true;
+    }
+  });
+
+  // クラス別名簿の絞り込み（全員 / 参加予定 / 来場済み / まだ）
+  document.querySelectorAll('.roster-filter').forEach(function(group) {
+    const pane = document.getElementById(group.dataset.target);
+    group.querySelectorAll('button[data-filter]').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        group.querySelectorAll('button').forEach(function(b){ b.classList.remove('active'); });
+        btn.classList.add('active');
+        const filter = btn.dataset.filter;
+        pane.querySelectorAll('tbody tr').forEach(function(tr) {
+          const attending = tr.dataset.attending === '1';
+          const arrived = tr.dataset.arrived === '1';
+          let show = true;
+          if (filter === 'attending') show = attending;
+          else if (filter === 'arrived') show = arrived;
+          else if (filter === 'pending') show = attending && !arrived;
+          tr.style.display = show ? '' : 'none';
+        });
+      });
+    });
+  });
+</script>
+{% endblock extra_js %}

--- a/reunion/templates/admin/roster.html
+++ b/reunion/templates/admin/roster.html
@@ -110,12 +110,12 @@
     <thead class="table-light">
       <tr id="headerRow">
         <th class="sortable" data-col="id" style="cursor:pointer;white-space:nowrap;">ID <span class="sort-icon text-muted">↕</span></th>
+        <th class="sortable" data-col="class" style="cursor:pointer;white-space:nowrap;">クラス <span class="sort-icon text-muted">↕</span></th>
+        <th class="sortable" data-col="number" style="cursor:pointer;white-space:nowrap;">出席番号 <span class="sort-icon text-muted">↕</span></th>
         <th class="sortable" data-col="name" style="cursor:pointer;white-space:nowrap;">氏名 <span class="sort-icon text-muted">↕</span></th>
         <th class="sortable" data-col="name_kana" style="cursor:pointer;white-space:nowrap;">氏名（カナ）<span class="sort-icon text-muted">↕</span></th>
         <th class="sortable" data-col="email" style="cursor:pointer;white-space:nowrap;">メールアドレス <span class="sort-icon text-muted">↕</span></th>
         <th class="sortable" data-col="role" style="cursor:pointer;white-space:nowrap;">役割 <span class="sort-icon text-muted">↕</span></th>
-        <th class="sortable" data-col="class" style="cursor:pointer;white-space:nowrap;">クラス <span class="sort-icon text-muted">↕</span></th>
-        <th class="sortable" data-col="number" style="cursor:pointer;white-space:nowrap;">出席番号 <span class="sort-icon text-muted">↕</span></th>
         <th class="sortable" data-col="memo" style="cursor:pointer;white-space:nowrap;">幹事メモ <span class="sort-icon text-muted">↕</span></th>
         <th class="sortable" data-col="prov" style="cursor:pointer;white-space:nowrap;">仮出欠 <span class="sort-icon text-muted">↕</span></th>
         <th class="sortable" data-col="final" style="cursor:pointer;white-space:nowrap;">本出欠 <span class="sort-icon text-muted">↕</span></th>
@@ -124,6 +124,8 @@
       </tr>
       <tr id="filterRow" class="table-secondary">
         <td><input type="text" class="form-control form-control-sm" id="f-id" placeholder="検索"></td>
+        <td><input type="text" class="form-control form-control-sm" id="f-class" placeholder="検索"></td>
+        <td><input type="text" class="form-control form-control-sm" id="f-number" placeholder="検索"></td>
         <td><input type="text" class="form-control form-control-sm" id="f-name" placeholder="検索"></td>
         <td><input type="text" class="form-control form-control-sm" id="f-name-kana" placeholder="検索"></td>
         <td><input type="text" class="form-control form-control-sm" id="f-email" placeholder="検索"></td>
@@ -136,8 +138,6 @@
             <option value="幹事">幹事</option>
           </select>
         </td>
-        <td><input type="text" class="form-control form-control-sm" id="f-class" placeholder="検索"></td>
-        <td><input type="text" class="form-control form-control-sm" id="f-number" placeholder="検索"></td>
         <td><input type="text" class="form-control form-control-sm" id="f-memo" placeholder="検索"></td>
         <td>
           <select class="form-select form-select-sm" id="f-prov">
@@ -176,6 +176,8 @@
       {% set role_sort = {'生徒': 0, '教師': 1, '学年主任': 2, '幹事': 3}.get(p.role, 9) %}
       <tr>
         <td data-col="id" data-val="{{ p.id }}" data-sort="{{ p.id }}" class="text-muted small">{{ p.id }}</td>
+        <td data-col="class" data-val="{{ p.class_name or '' }}" class="small text-center">{{ p.class_name or '' }}</td>
+        <td data-col="number" data-val="{{ p.student_number or '' }}" data-sort="{{ p.student_number if p.student_number and p.student_number.isdigit() else '9999' }}" class="small text-center">{{ p.student_number or '' }}</td>
         <td data-col="name" data-val="{{ p.name }}">
           <a href="{{ url_for('admin.participant_detail', participant_id=p.id) }}">{{ p.name }}</a>
         </td>
@@ -189,8 +191,6 @@
           {% elif p.role == '幹事' %}<span class="badge bg-info text-dark">幹事</span>
           {% else %}<span class="badge bg-primary">生徒</span>{% endif %}
         </td>
-        <td data-col="class" data-val="{{ p.class_name or '' }}" class="small text-center">{{ p.class_name or '' }}</td>
-        <td data-col="number" data-val="{{ p.student_number or '' }}" data-sort="{{ p.student_number if p.student_number and p.student_number.isdigit() else '9999' }}" class="small text-center">{{ p.student_number or '' }}</td>
         <td data-col="memo" data-val="{{ p.teacher_memo or '' }}" class="small text-muted">{{ p.teacher_memo or '' }}</td>
         <td data-col="prov" data-val="{{ prov_label }}">
           {% if prov %}

--- a/reunion/templates/attendance_scan.html
+++ b/reunion/templates/attendance_scan.html
@@ -11,7 +11,7 @@
     <div class="card shadow-sm">
       <div class="card-body p-4">
         <h2 class="h4 mb-3">会場出席登録</h2>
-        <p class="text-muted mb-4">お名前を選択してください。登録完了後、登録済みメールアドレスへ確認メールが届きます。</p>
+        <p class="text-muted mb-4">クラスとお名前を選択してください。登録完了後、登録済みメールアドレスへ確認メールが届きます。</p>
 
         {% with messages = get_flashed_messages(with_categories=true) %}
           {% if messages %}
@@ -21,36 +21,71 @@
           {% endif %}
         {% endwith %}
 
-        <form method="post">
-          <div class="mb-3">
-            <label for="name_filter" class="form-label">名前で検索</label>
-            <input id="name_filter" class="form-control mb-2" placeholder="名前の一部を入力すると絞り込まれます">
-            <label for="participant_id" class="form-label">参加者名</label>
-            <select class="form-select" id="participant_id" name="participant_id" required>
-              <option value="">選択してください</option>
-              {% for participant in participants %}
-              <option value="{{ participant.id }}">{{ participant.name }}{% if participant.class_name %}（{{ participant.class_name }}）{% endif %}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <button type="submit" class="btn btn-primary w-100">出席を登録する</button>
+        <div class="mb-3">
+          <label for="class_select" class="form-label fw-bold">クラス <span class="text-danger">*</span></label>
+          <select class="form-select" id="class_select">
+            <option value="">-- クラスを選択 --</option>
+            <option value="31">31</option>
+            <option value="32">32</option>
+            <option value="33">33</option>
+            <option value="34">34</option>
+            <option value="35">35</option>
+            <option value="36">36</option>
+            <option value="37">37</option>
+            <option value="38">38</option>
+            <option value="39">39</option>
+            <option value="teacher">教職員</option>
+          </select>
+        </div>
+        <div class="mb-3 d-none" id="name_select_group">
+          <label for="name_select" class="form-label fw-bold">お名前 <span class="text-danger">*</span></label>
+          <select class="form-select" id="name_select" disabled>
+            <option value="">-- 名前を選択 --</option>
+          </select>
+        </div>
+        <form method="post" id="checkin_form">
+          <input type="hidden" name="participant_id" id="participant_id" value="">
+          <button type="submit" class="btn btn-primary w-100" id="checkin_btn" disabled>出席を登録する</button>
         </form>
+
         <script>
-          (function(){
-            const filter = document.getElementById('name_filter');
-            const select = document.getElementById('participant_id');
-            filter.addEventListener('input', function(){
-              const q = this.value.trim().toLowerCase();
-              let firstVisible = null;
-              for (let i=0;i<select.options.length;i++){
-                const opt = select.options[i];
-                if (!q) { opt.hidden = false; if(firstVisible===null && opt.value) firstVisible = opt; continue; }
-                const txt = opt.text.toLowerCase();
-                if (txt.indexOf(q) !== -1) { opt.hidden = false; if(firstVisible===null && opt.value) firstVisible = opt; } else { opt.hidden = true; }
-              }
-              if(firstVisible) select.value = firstVisible.value;
+          const classSelect     = document.getElementById('class_select');
+          const nameSelectGroup = document.getElementById('name_select_group');
+          const nameSelect      = document.getElementById('name_select');
+          const participantId   = document.getElementById('participant_id');
+          const checkinBtn      = document.getElementById('checkin_btn');
+
+          classSelect.addEventListener('change', async function() {
+            const cls = classSelect.value;
+            nameSelect.innerHTML = '<option value="">読み込み中...</option>';
+            nameSelect.disabled = true;
+            checkinBtn.disabled = true;
+            participantId.value = '';
+
+            if (!cls) {
+              nameSelectGroup.classList.add('d-none');
+              return;
+            }
+
+            nameSelectGroup.classList.remove('d-none');
+            const res = await fetch("{{ url_for('forms.api_names') }}?class=" + cls);
+            const names = await res.json();
+
+            nameSelect.innerHTML = '<option value="">-- 名前を選択 --</option>';
+            names.forEach(function(p) {
+              const opt = document.createElement('option');
+              opt.value = p.id;
+              const isTeacher = p.role === '教師' || p.role === '学年主任';
+              opt.textContent = isTeacher ? p.name + ' 先生' : p.name;
+              nameSelect.appendChild(opt);
             });
-          })();
+            nameSelect.disabled = false;
+          });
+
+          nameSelect.addEventListener('change', function() {
+            participantId.value = nameSelect.value;
+            checkinBtn.disabled = !nameSelect.value;
+          });
         </script>
       </div>
     </div>

--- a/reunion/templates/base.html
+++ b/reunion/templates/base.html
@@ -83,6 +83,74 @@
     同窓会管理アプリ
   </footer>
 
+  <!-- 下部ナビ（スマホアプリ風） -->
+  <nav class="app-bottom-nav">
+    <a class="bottom-nav-item {% if request.endpoint in ('admin.participants', 'admin.participant_detail', 'admin.roster') %}active{% endif %}"
+       href="{{ url_for('admin.participants') }}">
+      <i class="bi bi-person-gear"></i><span>参加者</span>
+    </a>
+    <a class="bottom-nav-item {% if request.endpoint in ('admin.mail_hub', 'admin.settings_mail', 'admin.settings_mail_template') %}active{% endif %}"
+       href="{{ url_for('admin.mail_hub') }}">
+      <i class="bi bi-envelope-fill"></i><span>メール</span>
+    </a>
+    <a class="bottom-nav-item bottom-nav-home {% if request.endpoint == 'admin.index' %}active{% endif %}"
+       href="{{ url_for('admin.index') }}">
+      <i class="bi bi-house-fill"></i><span>ホーム</span>
+    </a>
+    <a class="bottom-nav-item {% if request.endpoint in ('admin.payments', 'admin.csv_import') %}active{% endif %}"
+       href="{{ url_for('admin.payments') }}">
+      <i class="bi bi-cash-stack"></i><span>入金</span>
+    </a>
+    <button type="button" class="bottom-nav-item {% if request.endpoint == 'admin.qr_attendance' %}active{% endif %}"
+            data-bs-toggle="offcanvas" data-bs-target="#registerSheet">
+      <i class="bi bi-clipboard-check"></i><span>登録</span>
+    </button>
+  </nav>
+
+  <!-- 登録系メニュー（下から出るシート） -->
+  <div class="offcanvas offcanvas-bottom register-sheet" tabindex="-1" id="registerSheet">
+    <div class="offcanvas-header pb-0">
+      <h5 class="offcanvas-title"><i class="bi bi-clipboard-check me-2"></i>登録</h5>
+      <button type="button" class="btn-close" data-bs-dismiss="offcanvas"></button>
+    </div>
+    <div class="offcanvas-body">
+      <div class="list-group list-group-flush">
+        <a href="{{ url_for('forms.provisional') }}" target="_blank" class="list-group-item list-group-item-action d-flex align-items-center gap-3 py-3">
+          <i class="bi bi-pencil-square fs-4 text-primary"></i>
+          <div>
+            <div class="fw-bold">仮出欠フォーム</div>
+            <div class="small text-muted">参加者向けの仮出欠登録</div>
+          </div>
+          <i class="bi bi-box-arrow-up-right ms-auto text-muted"></i>
+        </a>
+        <a href="{{ url_for('admin.final_form_preview') }}" target="_blank" class="list-group-item list-group-item-action d-flex align-items-center gap-3 py-3">
+          <i class="bi bi-check2-square fs-4 text-success"></i>
+          <div>
+            <div class="fw-bold">本出欠フォーム</div>
+            <div class="small text-muted">本出欠フォームのプレビュー</div>
+          </div>
+          <i class="bi bi-box-arrow-up-right ms-auto text-muted"></i>
+        </a>
+        <a href="{{ url_for('attendance_scan') }}" target="_blank" class="list-group-item list-group-item-action d-flex align-items-center gap-3 py-3">
+          <i class="bi bi-person-check fs-4 text-info"></i>
+          <div>
+            <div class="fw-bold">当日出席フォーム</div>
+            <div class="small text-muted">QRを読み込んだ参加者が見る画面</div>
+          </div>
+          <i class="bi bi-box-arrow-up-right ms-auto text-muted"></i>
+        </a>
+        <a href="{{ url_for('admin.qr_attendance') }}" class="list-group-item list-group-item-action d-flex align-items-center gap-3 py-3">
+          <i class="bi bi-qr-code-scan fs-4 text-warning"></i>
+          <div>
+            <div class="fw-bold">当日出席登録</div>
+            <div class="small text-muted">会場QR出席管理・クラス別名簿</div>
+          </div>
+          <i class="bi bi-chevron-right ms-auto text-muted"></i>
+        </a>
+      </div>
+    </div>
+  </div>
+
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="{{ url_for('static', filename='js/main.js') }}"></script>
   {% block extra_js %}{% endblock %}

--- a/reunion/templates/status.html
+++ b/reunion/templates/status.html
@@ -157,7 +157,9 @@
       .filter(p => p[type] !== 'no_response')
       .map(p => {
         const displayName = p.name;
+        const classNum = (p.class_name || '-') + (p.number ? '-' + p.number : '');
         return `<div class="person-row" data-prov="${p.prov}" data-final="${p.final}">
+          <span class="text-muted small me-2">${classNum}</span>
           <span class="flex-grow-1">${displayName}</span>
           <span class="badge person-badge ms-2"></span>
         </div>`;


### PR DESCRIPTION
- 会場QR出席管理: 幹事用クラス別名簿タブを追加（名前順、参加予定/来場済み/まだの絞り込み、出席登録ボタン）
- ダッシュボード: 円グラフ3つを共通スペースのタブ切替に統合、参加状況ボタンを追加
- base: スマホアプリ風の下部5アイコンナビと登録シート（仮出欠/本出欠/当日出席フォーム/当日出席登録）を追加
- 参加者管理: 氏名の折り返し防止、スマホで補助列を非表示、操作4ボタンを2×2グリッド化
- attendance/scan: 名前検索方式を廃止し、管理画面と同じクラス→名前選択方式に変更
- 全名簿（参加者管理/名簿管理/QR出席/入金/メール送信対象/参加状況）で名前の左にクラス・出席番号を表示