### PR TITLE
名簿の氏名にカナをルビ表示・クラス別名簿のスマホ表示を圧縮・参加者一覧は氏名を先頭列に

### DIFF
--- a/reunion/templates/admin/participants.html
+++ b/reunion/templates/admin/participants.html
@@ -65,6 +65,8 @@
   .filter-active { color:#0d6efd !important; }
   /* 氏名などのセル内改行を防ぎ、はみ出す分は横スクロールさせる */
   #listPane .table td { white-space:nowrap; }
+  /* カナは氏名の上にルビとして表示 */
+  #listPane .table ruby rt { font-size:.55em; color:#6c757d; letter-spacing:.02em; }
   /* 操作ボタン: スマホは2×2グリッド、md以上は右寄せ横並び */
   .participant-actions { display:grid; grid-template-columns:1fr 1fr; gap:.5rem; }
   .participant-actions .btn { white-space:nowrap; }
@@ -81,6 +83,9 @@
   <table class="table table-hover table-sm align-middle">
     <thead class="table-light">
       <tr>
+        <th class="th-filter">
+          <a href="{{ sort_url('name') }}">氏名 <i class="bi {{ sort_icon('name') }}"></i></a>
+        </th>
         <th class="d-none d-md-table-cell">ID</th>
         <th class="th-filter">
           <div class="dropdown d-inline">
@@ -102,9 +107,6 @@
         </th>
         <th class="th-filter">
           <a href="{{ sort_url('number') }}">番号 <i class="bi {{ sort_icon('number') }}"></i></a>
-        </th>
-        <th class="th-filter">
-          <a href="{{ sort_url('name') }}">氏名 <i class="bi {{ sort_icon('name') }}"></i></a>
         </th>
         <th class="th-filter">
           <div class="dropdown d-inline">
@@ -193,12 +195,16 @@
       {% set prov = p.latest_provisional %}
       {% set final = p.latest_final %}
       <tr>
+        <td class="text-nowrap">
+          {% if p.name_kana %}
+          <ruby>{{ p.display_name }}<rt>{{ p.name_kana }}</rt></ruby>
+          {% else %}
+          {{ p.display_name }}
+          {% endif %}
+        </td>
         <td class="text-muted small d-none d-md-table-cell">{{ p.id }}</td>
         <td class="small text-center">{{ p.class_name or '' }}</td>
         <td class="small text-center">{{ p.student_number or '' }}</td>
-        <td>
-          {{ p.display_name }}
-        </td>
         <td class="small">
           {% if p.role == '教師' %}<span class="badge bg-warning text-dark">教師</span>
           {% elif p.role == '学年主任' %}<span class="badge bg-danger">学年主任</span>

--- a/reunion/templates/admin/qr_attendance.html
+++ b/reunion/templates/admin/qr_attendance.html
@@ -1,6 +1,20 @@
 {% extends 'base.html' %}
 {% block title %}会場QR出席管理{% endblock %}
 
+{% block extra_head %}
+<style>
+  /* カナは名前の上にルビとして表示 */
+  .roster-table ruby rt { font-size: .55em; color: #6c757d; letter-spacing: .02em; }
+  /* スマホでは詰めて表示 */
+  @media (max-width: 576px) {
+    .roster-table { font-size: .85rem; }
+    .roster-table td, .roster-table th { padding: .3rem .35rem; }
+    .roster-table .btn { font-size: .72rem; padding: .15rem .4rem; }
+    .roster-table .badge { font-size: .68rem; }
+  }
+</style>
+{% endblock %}
+
 {% block content %}
 <div class="container-fluid">
   <div class="d-flex justify-content-between align-items-center mb-4">
@@ -94,7 +108,7 @@
               </div>
               {% if cls.members %}
               <div class="table-responsive">
-                <table class="table table-sm align-middle mb-0">
+                <table class="table table-sm align-middle mb-0 roster-table">
                   <thead>
                     <tr>
                       <th>組-番</th>
@@ -113,9 +127,12 @@
                       <td class="small text-muted text-nowrap">
                         {{ p.class_name or '-' }}{% if p.student_number %}-{{ p.student_number }}{% endif %}
                       </td>
-                      <td>
+                      <td class="text-nowrap">
+                        {% if p.name_kana %}
+                        <ruby>{{ p.name }}<rt>{{ p.name_kana }}</rt></ruby>{% if p.role in ['教師', '学年主任'] %} 先生{% endif %}
+                        {% else %}
                         {{ p.name }}{% if p.role in ['教師', '学年主任'] %} 先生{% endif %}
-                        {% if p.name_kana %}<span class="small text-muted ms-1">{{ p.name_kana }}</span>{% endif %}
+                        {% endif %}
                       </td>
                       <td>
                         {% if m.final_attending %}


### PR DESCRIPTION
- QRクラス別名簿: カナ列を氏名上のルビに変更、スマホでセル余白・フォントを縮小
- 参加者一覧: 氏名を一番左の列に移動し、カナをルビ表示