### PR TITLE
参加者一覧の行タップで詳細へ遷移・詳細に基本情報の編集機能とフリガナ表示を追加

### DIFF
--- a/reunion/routes/admin.py
+++ b/reunion/routes/admin.py
@@ -499,6 +499,38 @@ def update_memo(participant_id):
     return redirect(url_for("admin.participant_detail", participant_id=participant_id))
 
 
+@admin_bp.route("/participant/<int:participant_id>/update-basic", methods=["POST"])
+def update_basic_info(participant_id):
+    """基本情報（氏名・フリガナ・メール・クラス・出席番号）を更新"""
+    participant = db.session.get(Participant, participant_id)
+    if participant is None:
+        flash("参加者が見つかりません。", "danger")
+        return redirect(url_for("admin.participants"))
+
+    name = request.form.get("name", "").strip()
+    email = request.form.get("email", "").strip()
+    if not name or not email:
+        flash("氏名とメールアドレスは必須です。", "danger")
+        return redirect(url_for("admin.participant_detail", participant_id=participant_id))
+
+    duplicate = Participant.query.filter(
+        Participant.email == email, Participant.id != participant_id
+    ).first()
+    if duplicate:
+        flash(f"メールアドレス {email} は {duplicate.name} さんが既に使用しています。", "danger")
+        return redirect(url_for("admin.participant_detail", participant_id=participant_id))
+
+    participant.name = name
+    participant.name_kana = request.form.get("name_kana", "").strip()
+    participant.email = email
+    participant.class_name = request.form.get("class_name", "").strip()
+    participant.student_number = request.form.get("student_number", "").strip()
+    participant.updated_at = datetime.utcnow()
+    db.session.commit()
+    flash("基本情報を更新しました。", "success")
+    return redirect(url_for("admin.participant_detail", participant_id=participant_id))
+
+
 @admin_bp.route("/participant/<int:participant_id>/clear-responses", methods=["POST"])
 def clear_responses(participant_id):
     """参加者の回答・入金データを全てクリアして未回答状態に戻す"""

--- a/reunion/templates/admin/participant_detail.html
+++ b/reunion/templates/admin/participant_detail.html
@@ -49,19 +49,62 @@
   <!-- 基本情報 -->
   <div class="col-md-6">
     <div class="card h-100">
-      <div class="card-header fw-bold bg-light">基本情報</div>
+      <div class="card-header fw-bold bg-light d-flex justify-content-between align-items-center">
+        基本情報
+        <button type="button" class="btn btn-outline-primary btn-sm" id="basicEditBtn">
+          <i class="bi bi-pencil me-1"></i>編集
+        </button>
+      </div>
       <div class="card-body">
-        <dl class="row mb-0">
+        <dl class="row mb-0" id="basicInfoView">
           <dt class="col-4">氏名</dt>
           <dd class="col-8">
             {{ participant.display_name }}
           </dd>
+          <dt class="col-4">フリガナ</dt>
+          <dd class="col-8">{{ participant.name_kana or '-' }}</dd>
           <dt class="col-4">メール</dt><dd class="col-8">{{ participant.email }}</dd>
+          <dt class="col-4">クラス</dt><dd class="col-8">{{ participant.class_name or '-' }}</dd>
+          <dt class="col-4">出席番号</dt><dd class="col-8">{{ participant.student_number or '-' }}</dd>
           <dt class="col-4">登録日時</dt>
           <dd class="col-8 small text-muted">{{ participant.created_at | jst }}</dd>
           <dt class="col-4">更新日時</dt>
           <dd class="col-8 small text-muted">{{ participant.updated_at | jst }}</dd>
         </dl>
+        <form method="POST" action="{{ url_for('admin.update_basic_info', participant_id=participant.id) }}"
+              class="d-none" id="basicInfoForm">
+          <div class="mb-2">
+            <label class="form-label form-label-sm fw-bold mb-1">氏名 <span class="text-danger">*</span></label>
+            <input type="text" class="form-control form-control-sm" name="name"
+                   value="{{ participant.name }}" required>
+          </div>
+          <div class="mb-2">
+            <label class="form-label form-label-sm fw-bold mb-1">フリガナ</label>
+            <input type="text" class="form-control form-control-sm" name="name_kana"
+                   value="{{ participant.name_kana or '' }}" placeholder="ヤマダタロウ">
+          </div>
+          <div class="mb-2">
+            <label class="form-label form-label-sm fw-bold mb-1">メールアドレス <span class="text-danger">*</span></label>
+            <input type="email" class="form-control form-control-sm" name="email"
+                   value="{{ participant.email }}" required>
+          </div>
+          <div class="row g-2 mb-3">
+            <div class="col">
+              <label class="form-label form-label-sm fw-bold mb-1">クラス</label>
+              <input type="text" class="form-control form-control-sm" name="class_name"
+                     value="{{ participant.class_name or '' }}" placeholder="31">
+            </div>
+            <div class="col">
+              <label class="form-label form-label-sm fw-bold mb-1">出席番号</label>
+              <input type="text" class="form-control form-control-sm" name="student_number"
+                     value="{{ participant.student_number or '' }}" placeholder="5">
+            </div>
+          </div>
+          <div class="d-flex gap-2">
+            <button type="submit" class="btn btn-primary btn-sm">保存</button>
+            <button type="button" class="btn btn-outline-secondary btn-sm" id="basicCancelBtn">キャンセル</button>
+          </div>
+        </form>
       </div>
     </div>
   </div>
@@ -371,6 +414,23 @@
 
 {% block extra_js %}
 <script>
+// 基本情報の表示/編集切り替え
+(function() {
+  var view = document.getElementById('basicInfoView');
+  var form = document.getElementById('basicInfoForm');
+  var editBtn = document.getElementById('basicEditBtn');
+  document.getElementById('basicEditBtn').addEventListener('click', function() {
+    view.classList.add('d-none');
+    form.classList.remove('d-none');
+    editBtn.classList.add('d-none');
+  });
+  document.getElementById('basicCancelBtn').addEventListener('click', function() {
+    form.classList.add('d-none');
+    view.classList.remove('d-none');
+    editBtn.classList.remove('d-none');
+  });
+})();
+
 function copyUrl() {
   const input = document.getElementById('finalUrl');
   navigator.clipboard.writeText(input.value).then(() => {

--- a/reunion/templates/admin/participants.html
+++ b/reunion/templates/admin/participants.html
@@ -67,6 +67,8 @@
   #listPane .table td { white-space:nowrap; }
   /* カナは氏名の上にルビとして表示 */
   #listPane .table ruby rt { font-size:.55em; color:#6c757d; letter-spacing:.02em; }
+  /* 行タップで詳細へ */
+  .participant-row { cursor:pointer; }
   /* 操作ボタン: スマホは2×2グリッド、md以上は右寄せ横並び */
   .participant-actions { display:grid; grid-template-columns:1fr 1fr; gap:.5rem; }
   .participant-actions .btn { white-space:nowrap; }
@@ -194,7 +196,7 @@
       {% for p in participants %}
       {% set prov = p.latest_provisional %}
       {% set final = p.latest_final %}
-      <tr>
+      <tr class="participant-row" data-href="{{ url_for('admin.participant_detail', participant_id=p.id) }}">
         <td class="text-nowrap">
           {% if p.name_kana %}
           <ruby>{{ p.display_name }}<rt>{{ p.name_kana }}</rt></ruby>
@@ -379,6 +381,14 @@
   sessionStorage.setItem('participantListUrl', location.href);
   var ids = [{% for p in participants %}{{ p.id }}{% if not loop.last %},{% endif %}{% endfor %}];
   sessionStorage.setItem('participantListIds', JSON.stringify(ids));
+
+  // 行タップで詳細ページへ（行内のリンク・ボタンのクリックは除く）
+  document.querySelectorAll('.participant-row').forEach(function(tr) {
+    tr.addEventListener('click', function(e) {
+      if (e.target.closest('a, button')) return;
+      window.location.href = tr.dataset.href;
+    });
+  });
 })();
 </script>
 {% endblock %}


### PR DESCRIPTION
- 参加者一覧: 行クリックで詳細ページに遷移（行内のリンク・ボタンは除外）
- 参加者詳細: 基本情報にフリガナ・クラス・出席番号を表示、編集ボタンで氏名/フリガナ/メール/クラス/出席番号をインライン編集可能に
- update-basic ルートを新設（必須チェック・メール重複チェック付き）