### PR TITLE
管理画面と参加状況詳細にパスワードログインを追加

### DIFF
--- a/reunion/.env.example
+++ b/reunion/.env.example
@@ -8,6 +8,9 @@
 SECRET_KEY=change-me-to-random-string-please
 FLASK_ENV=development
 
+# 管理画面ログインパスワード（未設定だと管理画面にログインできません）
+ADMIN_PASSWORD=change-me-to-admin-password
+
 # --- データベース ---
 # デフォルトは instance/reunion.db（変更不要）
 # DATABASE_URL=sqlite:///reunion.db

--- a/reunion/app.py
+++ b/reunion/app.py
@@ -109,9 +109,46 @@ def create_app():
     def index():
         return redirect(url_for("admin.index"))
 
+    # -----------------------------------------------
+    # 管理画面ログイン
+    # -----------------------------------------------
+    @app.route("/login", methods=["GET", "POST"])
+    def login():
+        import hmac
+        from flask import render_template, request, session, flash
+
+        if session.get("admin_authed"):
+            return redirect(url_for("admin.index"))
+
+        if request.method == "POST":
+            admin_password = app.config.get("ADMIN_PASSWORD", "")
+            password = request.form.get("password", "")
+            if not admin_password:
+                flash("ADMIN_PASSWORD が未設定のためログインできません。サーバーの環境変数（.env）に設定してください。", "danger")
+            elif hmac.compare_digest(password, admin_password):
+                session.permanent = True
+                session["admin_authed"] = True
+                nxt = request.form.get("next", "")
+                # オープンリダイレクト防止: サイト内の相対パスのみ許可
+                if not nxt.startswith("/") or nxt.startswith("//"):
+                    nxt = url_for("admin.index")
+                return redirect(nxt)
+            else:
+                flash("パスワードが違います。", "danger")
+
+        from flask import request as req
+        return render_template("login.html", next=req.args.get("next", "") or req.form.get("next", ""))
+
+    @app.route("/logout")
+    def logout():
+        from flask import session, flash
+        session.pop("admin_authed", None)
+        flash("ログアウトしました。", "success")
+        return redirect(url_for("login"))
+
     @app.route("/status")
     def status():
-        from flask import render_template, request
+        from flask import render_template, request, session
         from models import Participant
 
         def _class_label(cls):
@@ -122,6 +159,9 @@ def create_app():
         TEACHER_ROLES = {"教師", "学年主任", "副担任"}
 
         show_details = request.args.get("detail", "").lower() in {"1", "true", "yes", "on"}
+        # 名前入りの詳細表示はログイン必須（集計のみの表示は公開）
+        if show_details and not session.get("admin_authed"):
+            return redirect(url_for("login", next=request.full_path))
 
         participants = Participant.query.all()
         prov_stats  = {"attending": 0, "not_attending": 0, "undecided": 0, "no_response": 0}

--- a/reunion/config.py
+++ b/reunion/config.py
@@ -3,6 +3,7 @@ config.py - アプリ設定管理
 .env ファイルから設定を読み込み、Flaskアプリに渡す
 """
 import os
+from datetime import timedelta
 from pathlib import Path
 from dotenv import load_dotenv
 
@@ -16,6 +17,13 @@ class Config:
     # -----------------------------------------------
     SECRET_KEY = os.getenv("SECRET_KEY", "dev-secret-key-please-change")
     FLASK_ENV = os.getenv("FLASK_ENV", "development")
+
+    # -----------------------------------------------
+    # 管理画面ログイン
+    # 未設定の場合は管理画面にログインできない（fail-closed）
+    # -----------------------------------------------
+    ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "")
+    PERMANENT_SESSION_LIFETIME = timedelta(days=30)
 
     # -----------------------------------------------
     # データベース設定

--- a/reunion/routes/admin.py
+++ b/reunion/routes/admin.py
@@ -42,6 +42,14 @@ logger = logging.getLogger(__name__)
 admin_bp = Blueprint("admin", __name__, url_prefix="/admin")
 
 
+@admin_bp.before_request
+def require_admin_auth():
+    """管理画面全体にログインを必須にする"""
+    from flask import session
+    if not session.get("admin_authed"):
+        return redirect(url_for("login", next=request.full_path))
+
+
 # -----------------------------------------------
 # ダッシュボード
 # -----------------------------------------------

--- a/reunion/templates/base.html
+++ b/reunion/templates/base.html
@@ -54,6 +54,11 @@
               <i class="bi bi-box-arrow-up-right me-1"></i>本出欠フォーム
             </a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="{{ url_for('logout') }}">
+              <i class="bi bi-box-arrow-right me-1"></i>ログアウト
+            </a>
+          </li>
         </ul>
       </div>
     </div>

--- a/reunion/templates/login.html
+++ b/reunion/templates/login.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ログイン | 同窓会管理</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+  <div class="container py-5" style="max-width: 420px;">
+    <div class="card shadow-sm mt-5">
+      <div class="card-body p-4">
+        <h2 class="h5 mb-1"><i class="bi bi-people-fill me-2"></i>同窓会管理</h2>
+        <p class="text-muted small mb-4">管理画面に入るにはパスワードが必要です。</p>
+
+        {% with messages = get_flashed_messages(with_categories=true) %}
+          {% if messages %}
+            {% for category, message in messages %}
+              <div class="alert alert-{{ category }} py-2 small">{{ message }}</div>
+            {% endfor %}
+          {% endif %}
+        {% endwith %}
+
+        <form method="post" action="{{ url_for('login') }}">
+          <input type="hidden" name="next" value="{{ next }}">
+          <div class="mb-3">
+            <label for="password" class="form-label fw-bold">パスワード</label>
+            <input type="password" class="form-control" id="password" name="password"
+                   autocomplete="current-password" autofocus required>
+          </div>
+          <button type="submit" class="btn btn-primary w-100">
+            <i class="bi bi-box-arrow-in-right me-1"></i>ログイン
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
- /admin 全体と /status?detail=1 をセッション認証で保護（参加者向けフォーム・集計は公開のまま）
- ADMIN_PASSWORD 環境変数でパスワード設定（未設定時はログイン不可のfail-closed）
- /login /logout ルートとログイン画面を追加、セッションは30日保持
- next パラメータのオープンリダイレクト対策、hmac.compare_digest でパスワード比較
- .env.example に ADMIN_PASSWORD を追記