### PR TITLE
ログインを幹事長/クラス幹事の2段階に分離

### DIFF
--- a/reunion/.env.example
+++ b/reunion/.env.example
@@ -11,6 +11,9 @@ FLASK_ENV=development
 # 管理画面ログインパスワード（未設定だと管理画面にログインできません）
 ADMIN_PASSWORD=change-me-to-admin-password
 
+# 参加状況の詳細表示（/status?detail=1）の閲覧用パスワード（幹事メンバー向け）
+STATUS_PASSWORD=change-me-to-status-password
+
 # --- データベース ---
 # デフォルトは instance/reunion.db（変更不要）
 # DATABASE_URL=sqlite:///reunion.db

--- a/reunion/app.py
+++ b/reunion/app.py
@@ -112,20 +112,22 @@ def create_app():
     # -----------------------------------------------
     # 管理画面ログイン
     # -----------------------------------------------
-    def _safe_next(nxt):
+    def _safe_next(nxt, default):
         """サイト内の相対パスのみ許可（オープンリダイレクト防止）"""
         if nxt and nxt.startswith("/") and not nxt.startswith("//"):
             return nxt
-        return url_for("admin.index")
+        return default
 
     @app.route("/login", methods=["GET", "POST"])
     def login():
+        """管理画面（/admin）用ログイン"""
         import hmac
         from flask import render_template, request, session, flash
 
+        default_next = url_for("admin.index")
         if session.get("admin_authed"):
             # ログイン済みでも next があればそこへ戻す
-            return redirect(_safe_next(request.args.get("next", "")))
+            return redirect(_safe_next(request.args.get("next", ""), default_next))
 
         if request.method == "POST":
             admin_password = app.config.get("ADMIN_PASSWORD", "")
@@ -135,18 +137,49 @@ def create_app():
             elif hmac.compare_digest(password, admin_password):
                 session.permanent = True
                 session["admin_authed"] = True
-                return redirect(_safe_next(request.form.get("next", "")))
+                return redirect(_safe_next(request.form.get("next", ""), default_next))
             else:
                 flash("パスワードが違います。", "danger")
 
         return render_template("login.html", next=request.args.get("next", "") or request.form.get("next", ""))
 
+    @app.route("/status/login", methods=["GET", "POST"])
+    def status_login():
+        """参加状況の詳細表示（/status?detail=1）閲覧用ログイン"""
+        import hmac
+        from flask import render_template, request, session, flash
+
+        default_next = url_for("status", detail=1)
+        if session.get("status_authed") or session.get("admin_authed"):
+            return redirect(_safe_next(request.args.get("next", ""), default_next))
+
+        if request.method == "POST":
+            status_password = app.config.get("STATUS_PASSWORD", "")
+            admin_password = app.config.get("ADMIN_PASSWORD", "")
+            password = request.form.get("password", "")
+            if not status_password:
+                flash("STATUS_PASSWORD が未設定のためログインできません。サーバーの環境変数（.env）に設定してください。", "danger")
+            elif hmac.compare_digest(password, status_password):
+                session.permanent = True
+                session["status_authed"] = True
+                return redirect(_safe_next(request.form.get("next", ""), default_next))
+            elif admin_password and hmac.compare_digest(password, admin_password):
+                # 管理者パスワードでも閲覧可能
+                session.permanent = True
+                session["admin_authed"] = True
+                return redirect(_safe_next(request.form.get("next", ""), default_next))
+            else:
+                flash("パスワードが違います。", "danger")
+
+        return render_template("status_login.html", next=request.args.get("next", "") or request.form.get("next", ""))
+
     @app.route("/logout")
     def logout():
         from flask import session, flash
-        session.pop("admin_authed", None)
+        was_admin = session.pop("admin_authed", None)
+        session.pop("status_authed", None)
         flash("ログアウトしました。", "success")
-        return redirect(url_for("login"))
+        return redirect(url_for("login" if was_admin else "status_login"))
 
     @app.route("/status")
     def status():
@@ -162,9 +195,9 @@ def create_app():
 
         show_details = request.args.get("detail", "").lower() in {"1", "true", "yes", "on"}
         # 名前入りの詳細表示はログイン必須（集計のみの表示は公開）
-        if show_details and not session.get("admin_authed"):
+        if show_details and not (session.get("status_authed") or session.get("admin_authed")):
             from urllib.parse import quote
-            return redirect(url_for("login") + "?next=" + quote(request.full_path, safe=""))
+            return redirect(url_for("status_login") + "?next=" + quote(request.full_path, safe=""))
 
         participants = Participant.query.all()
         prov_stats  = {"attending": 0, "not_attending": 0, "undecided": 0, "no_response": 0}

--- a/reunion/config.py
+++ b/reunion/config.py
@@ -19,10 +19,12 @@ class Config:
     FLASK_ENV = os.getenv("FLASK_ENV", "development")
 
     # -----------------------------------------------
-    # 管理画面ログイン
-    # 未設定の場合は管理画面にログインできない（fail-closed）
+    # ログインパスワード（未設定の場合はログインできない fail-closed）
+    #   ADMIN_PASSWORD:  管理画面（/admin）用
+    #   STATUS_PASSWORD: 参加状況の詳細表示（/status?detail=1）閲覧用
     # -----------------------------------------------
     ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "")
+    STATUS_PASSWORD = os.getenv("STATUS_PASSWORD", "")
     PERMANENT_SESSION_LIFETIME = timedelta(days=30)
 
     # -----------------------------------------------

--- a/reunion/templates/status_login.html
+++ b/reunion/templates/status_login.html
@@ -3,22 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>管理画面ログイン | 同窓会管理</title>
+  <title>参加状況の閲覧 | 同窓会</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
 </head>
 <body class="bg-light">
   <div class="container py-5" style="max-width: 420px;">
     <div class="card shadow-sm mt-4 overflow-hidden">
-      <div class="card-header bg-primary text-white text-center py-4">
-        <i class="bi bi-shield-lock-fill" style="font-size:2.2rem;"></i>
-        <h2 class="h5 mb-0 mt-2">管理画面ログイン</h2>
-        <div class="small mt-1" style="opacity:.85;">幹事長専用</div>
+      <div class="card-header bg-success text-white text-center py-4">
+        <i class="bi bi-bar-chart-fill" style="font-size:2.2rem;"></i>
+        <h2 class="h5 mb-0 mt-2">参加状況の閲覧</h2>
+        <div class="small mt-1" style="opacity:.85;">クラス幹事用</div>
       </div>
       <div class="card-body p-4">
         <p class="text-muted small mb-4">
-          名簿・メール送信・入金管理などを行う<strong>幹事長用</strong>の画面です。<br>
-          幹事長パスワードを入力してください。
+          クラスごとの回答状況（名前入り）を見るページです。<br>
+          <strong>クラス幹事パスワード</strong>を入力してください。
         </p>
 
         {% with messages = get_flashed_messages(with_categories=true) %}
@@ -29,22 +29,25 @@
           {% endif %}
         {% endwith %}
 
-        <form method="post" action="{{ url_for('login') }}">
+        <form method="post" action="{{ url_for('status_login') }}">
           <input type="hidden" name="next" value="{{ next }}">
           <div class="mb-3">
-            <label for="password" class="form-label fw-bold">幹事長パスワード</label>
+            <label for="password" class="form-label fw-bold">クラス幹事パスワード</label>
             <input type="password" class="form-control" id="password" name="password"
                    autocomplete="current-password" autofocus required>
           </div>
-          <button type="submit" class="btn btn-primary w-100">
-            <i class="bi bi-box-arrow-in-right me-1"></i>管理画面に入る
+          <button type="submit" class="btn btn-success w-100">
+            <i class="bi bi-eye me-1"></i>参加状況を見る
           </button>
         </form>
 
         <hr class="my-4">
-        <div class="text-center small">
-          <a href="{{ url_for('status_login') }}" class="text-muted">
-            <i class="bi bi-bar-chart me-1"></i>参加状況の閲覧はこちら（クラス幹事用）
+        <div class="d-flex flex-column gap-1 text-center small">
+          <a href="{{ url_for('status') }}" class="text-muted">
+            <i class="bi bi-pie-chart me-1"></i>集計だけ見る（パスワード不要）
+          </a>
+          <a href="{{ url_for('login') }}" class="text-muted">
+            <i class="bi bi-gear me-1"></i>幹事長はこちら（管理画面ログイン）
           </a>
         </div>
       </div>


### PR DESCRIPTION
- STATUS_PASSWORD を新設し /status?detail=1 はクラス幹事パスワードで閲覧可能に
- /status/login（緑・クラス幹事用）と /login（青・幹事長専用）の2画面に分離、相互リンク付き
- 幹事長パスワードは status 閲覧にも有効（上位互換）、クラス幹事パスワードでは /admin 不可
- /status の集計のみ表示は引き続きパスワード不要