### PR TITLE
メール未登録者の基本情報編集でブラウザ検証エラーになる問題を修正

### DIFF
--- a/reunion/routes/admin.py
+++ b/reunion/routes/admin.py
@@ -518,9 +518,16 @@ def update_basic_info(participant_id):
 
     name = request.form.get("name", "").strip()
     email = request.form.get("email", "").strip()
-    if not name or not email:
-        flash("氏名とメールアドレスは必須です。", "danger")
+    if not name:
+        flash("氏名は必須です。", "danger")
         return redirect(url_for("admin.participant_detail", participant_id=participant_id))
+
+    if not email:
+        # メール未登録: 名簿取込と同形式のダミーメールを生成して保持する
+        class_ = request.form.get("class_name", "").strip()
+        email = f"__no_email_{name}_{class_}_{participant.role}@placeholder.local"
+        if Participant.query.filter(Participant.email == email, Participant.id != participant_id).first():
+            email = f"__no_email_{participant_id}_{name}@placeholder.local"
 
     duplicate = Participant.query.filter(
         Participant.email == email, Participant.id != participant_id

--- a/reunion/templates/admin/participant_detail.html
+++ b/reunion/templates/admin/participant_detail.html
@@ -63,7 +63,11 @@
           </dd>
           <dt class="col-4">フリガナ</dt>
           <dd class="col-8">{{ participant.name_kana or '-' }}</dd>
-          <dt class="col-4">メール</dt><dd class="col-8">{{ participant.email }}</dd>
+          <dt class="col-4">メール</dt>
+          <dd class="col-8">
+            {% if participant.email and '@placeholder.local' not in participant.email %}{{ participant.email }}
+            {% else %}<span class="text-muted">未登録</span>{% endif %}
+          </dd>
           <dt class="col-4">クラス</dt><dd class="col-8">{{ participant.class_name or '-' }}</dd>
           <dt class="col-4">出席番号</dt><dd class="col-8">{{ participant.student_number or '-' }}</dd>
           <dt class="col-4">ID</dt><dd class="col-8 small text-muted">{{ participant.id }}（システム管理番号）</dd>
@@ -85,9 +89,11 @@
                    value="{{ participant.name_kana or '' }}" placeholder="ヤマダタロウ">
           </div>
           <div class="mb-2">
-            <label class="form-label form-label-sm fw-bold mb-1">メールアドレス <span class="text-danger">*</span></label>
+            <label class="form-label form-label-sm fw-bold mb-1">メールアドレス</label>
+            {% set has_real_email = participant.email and '@placeholder.local' not in participant.email %}
             <input type="email" class="form-control form-control-sm" name="email"
-                   value="{{ participant.email }}" required>
+                   value="{{ participant.email if has_real_email else '' }}"
+                   placeholder="未登録の場合は空欄のまま">
           </div>
           <div class="row g-2 mb-3">
             <div class="col">


### PR DESCRIPTION
- ダミーメール（@placeholder.local）は表示上「未登録」とし、編集フォームでは空欄にする
- メール空欄での保存を許可し、内部でダミーメールを再生成して保持
- 実メールを入力した場合は従来どおり重複チェックの上で登録